### PR TITLE
Auto delete rabbitmq queue

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,7 +17,7 @@ protobuf = "2"
 # Postgres sql connection
 diesel = { version = "1.4", features = ["64-column-tables", "postgres", "chrono", "uuid", "uuidv07"] }
 diesel-derive-enum = { version = "1.1", features = ["postgres"] }
-uuid = "0.8"
+uuid = { version = "1", features = ["v4"] }
 
 # Zmq lib with async interface
 tmq = "0.3"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,7 +17,7 @@ protobuf = "2"
 # Postgres sql connection
 diesel = { version = "1.4", features = ["64-column-tables", "postgres", "chrono", "uuid", "uuidv07"] }
 diesel-derive-enum = { version = "1.1", features = ["postgres"] }
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "0.8", features = ["v4"] }
 
 # Zmq lib with async interface
 tmq = "0.3"

--- a/server/src/data_worker.rs
+++ b/server/src/data_worker.rs
@@ -135,10 +135,12 @@ impl DataWorker {
                 );
                 String::from("unknown_host")
             });
+        let uuid = uuid::Uuid::new_v4();
 
         let instance_name = &config.instance_name;
-        let real_time_queue_name = format!("loki_{}_{}_real_time", host_name, instance_name);
-        let reload_queue_name = format!("loki_{}_{}_reload", host_name, instance_name);
+        let real_time_queue_name =
+            format!("loki_{}_{}_real_time_{}", host_name, instance_name, uuid);
+        let reload_queue_name = format!("loki_{}_{}_reload_{}", host_name, instance_name, uuid);
 
         let data_source = match &config.data_source {
             DataSourceParams::Local(local_file_params) => {

--- a/server/src/data_worker.rs
+++ b/server/src/data_worker.rs
@@ -624,7 +624,11 @@ impl DataWorker {
         channel
             .queue_declare(
                 &self.real_time_queue_name,
-                QueueDeclareOptions::default(),
+                QueueDeclareOptions {
+                    exclusive: true,
+                    auto_delete: true,
+                    ..QueueDeclareOptions::default()
+                },
                 FieldTable::default(),
             )
             .await
@@ -671,7 +675,11 @@ impl DataWorker {
         channel
             .queue_declare(
                 &self.reload_queue_name,
-                QueueDeclareOptions::default(),
+                QueueDeclareOptions {
+                    exclusive: true,
+                    auto_delete: true,
+                    ..QueueDeclareOptions::default()
+                },
                 FieldTable::default(),
             )
             .await


### PR DESCRIPTION
When loki dies, we want the rabbitmq queues to be closed instead of staying alive forever.
This PR creates the queues with the "exclusive" and "auto_delete" flags to obtain the desired behavior.
See https://www.rabbitmq.com/queues.html

This PR also adds a random suffix to the name of the created queue, so as to avoid two distinct lokis to connect to the same queue.