### PR TITLE
[Docker] Use bin-only dependencies in docker

### DIFF
--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y libzmq3-dev libpq-dev cmake
 RUN cargo install --path server
 
 FROM debian:buster-slim
-RUN apt-get update && apt-get install -y libzmq3-dev libpq-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libzmq5 libpq5 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/loki_server /usr/local/bin/loki_server
 
 VOLUME /data


### PR DESCRIPTION
To improve loki docker size we install bin-only dependencies : 
- libzmq-dev -> libzmq5 
- libpq-dev -> libpq5