### PR TITLE
[Dependabot] Keep github-actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,19 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "/launch"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "/server"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "/random"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "/stop_areas"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Having a dependabot cargo at root project "/" is enough. -> We removed dependabot scan on sub-directories 