### PR TITLE
fix: 'new_with_path_style' is deprecated

### DIFF
--- a/server/src/data_downloader.rs
+++ b/server/src/data_downloader.rs
@@ -72,7 +72,7 @@ impl DataDownloader {
                     region: "".to_string(),
                     endpoint: config.bucket_region.clone(),
                 };
-                Bucket::new_with_path_style(&config.bucket_name, region, credentials)?
+                Bucket::new(&config.bucket_name, region, credentials)?.with_path_style()
             }
             // AWS Region
             Ok(region) => Bucket::new(&config.bucket_name, region, credentials)?,


### PR DESCRIPTION
Here is what the compiler is saying about it.

```
warning: use of deprecated associated function
`s3::Bucket::new_with_path_style`: please use `new` and modify with
`with_path_style`
  --> server/src/data_downloader.rs:75:25
   |
75 |                 Bucket::new_with_path_style(&config.bucket_name,
   region, credentials)?
   |                         ^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```