### PR TITLE
feat: split 'time' and 'load' functions

### DIFF
--- a/src/request/arrive_before.rs
+++ b/src/request/arrive_before.rs
@@ -249,9 +249,7 @@ where
         let departure_time_at_previous_stop = self
             .transit_data
             .departure_time_of(trip, &previous_position);
-        let load = self
-            .transit_data
-            .departure_load_of(trip, &previous_position);
+        let load = self.transit_data.load_after(trip, &previous_position);
         let new_criteria = Criteria {
             time: departure_time_at_previous_stop,
             nb_of_legs: waiting_criteria.nb_of_legs + 1,
@@ -332,9 +330,7 @@ where
         let departure_time_at_previous_position = self
             .transit_data
             .departure_time_of(trip, &previous_position);
-        let load = self
-            .transit_data
-            .departure_load_of(trip, &previous_position);
+        let load = self.transit_data.load_after(trip, &previous_position);
         Criteria {
             time: departure_time_at_previous_position,
             nb_of_legs: criteria.nb_of_legs,

--- a/src/request/depart_after.rs
+++ b/src/request/depart_after.rs
@@ -219,8 +219,8 @@ where
         waiting_criteria: &Criteria,
     ) -> Option<Criteria> {
         let has_board = self.transit_data.board_time_of(trip, position);
-        if let Some(board_timeload) = has_board {
-            if waiting_criteria.time > board_timeload.0 {
+        if let Some(board_time) = has_board {
+            if waiting_criteria.time > board_time {
                 return None;
             }
         } else {
@@ -228,8 +228,8 @@ where
         }
         let mission = self.transit_data.mission_of(trip);
         let next_position = self.transit_data.next_on_mission(position, &mission)?;
-        let (arrival_time_at_next_stop, load) =
-            self.transit_data.arrival_time_of(trip, &next_position);
+        let arrival_time_at_next_stop = self.transit_data.arrival_time_of(trip, &next_position);
+        let load = self.transit_data.arrival_load_of(trip, &next_position);
         let new_criteria = Criteria {
             time: arrival_time_at_next_stop,
             nb_of_legs: waiting_criteria.nb_of_legs + 1,
@@ -244,7 +244,7 @@ where
         let next_trip = self.transit_data.stay_in_next(trip, self.real_time_level)?;
         let mission = self.transit_data.mission_of(&next_trip);
         let first_position = self.transit_data.first_on_mission(&mission);
-        let (arrival_time_at_first_stop, _load) = self
+        let arrival_time_at_first_stop = self
             .transit_data
             .arrival_time_of(&next_trip, &first_position);
         let new_criteria = Criteria {
@@ -286,11 +286,11 @@ where
     ) -> Option<Criteria> {
         debug_assert!({
             let arrival_time = &onboard_criteria.time;
-            self.transit_data.arrival_time_of(trip, position).0 == *arrival_time
+            self.transit_data.arrival_time_of(trip, position) == *arrival_time
         });
         self.transit_data
             .debark_time_of(trip, position)
-            .map(|(debark_time, _)| Criteria {
+            .map(|debark_time| Criteria {
                 time: debark_time,
                 nb_of_legs: onboard_criteria.nb_of_legs,
                 fallback_duration: onboard_criteria.fallback_duration,
@@ -305,8 +305,8 @@ where
             .transit_data
             .next_on_mission(position, &mission)
             .unwrap();
-        let (arrival_time_at_next_position, load) =
-            self.transit_data.arrival_time_of(trip, &next_position);
+        let arrival_time_at_next_position = self.transit_data.arrival_time_of(trip, &next_position);
+        let load = self.transit_data.arrival_load_of(trip, &next_position);
         Criteria {
             time: arrival_time_at_next_position,
             nb_of_legs: criteria.nb_of_legs,
@@ -408,8 +408,7 @@ where
         let board_time = self
             .transit_data
             .board_time_of(trip, board_position)
-            .ok_or_else(|| NoBoardTime(trip.clone(), board_position.clone()))?
-            .0;
+            .ok_or_else(|| NoBoardTime(trip.clone(), board_position.clone()))?;
         Ok(board_time)
     }
 
@@ -433,8 +432,7 @@ where
                     last_vehicle_leg.trip.clone(),
                     last_vehicle_leg.board_position.clone(),
                 )
-            })?
-            .0;
+            })?;
 
         for (transfer, vehicle) in journey.connections.iter_mut().rev() {
             let new_board_time = self._maximize_leg_board_time(vehicle, current_time)?;

--- a/src/request/depart_after.rs
+++ b/src/request/depart_after.rs
@@ -229,7 +229,7 @@ where
         let mission = self.transit_data.mission_of(trip);
         let next_position = self.transit_data.next_on_mission(position, &mission)?;
         let arrival_time_at_next_stop = self.transit_data.arrival_time_of(trip, &next_position);
-        let load = self.transit_data.arrival_load_of(trip, &next_position);
+        let load = self.transit_data.load_before(trip, &next_position);
         let new_criteria = Criteria {
             time: arrival_time_at_next_stop,
             nb_of_legs: waiting_criteria.nb_of_legs + 1,
@@ -306,7 +306,7 @@ where
             .next_on_mission(position, &mission)
             .unwrap();
         let arrival_time_at_next_position = self.transit_data.arrival_time_of(trip, &next_position);
-        let load = self.transit_data.arrival_load_of(trip, &next_position);
+        let load = self.transit_data.load_before(trip, &next_position);
         Criteria {
             time: arrival_time_at_next_position,
             nb_of_legs: criteria.nb_of_legs,

--- a/src/response.rs
+++ b/src/response.rs
@@ -242,12 +242,12 @@ where
                 ));
             }
 
-            let debark_timeload = data.debark_time_of(trip, debark_position).ok_or_else(|| {
+            let debark_time = data.debark_time_of(trip, debark_position).ok_or_else(|| {
                 BadJourney::NoDebarkTime(self.first_vehicle.clone(), VehicleLegIdx::First)
             })?;
 
             let debark_stop = data.stop_of(debark_position, &mission);
-            (debark_stop, debark_timeload.0)
+            (debark_stop, debark_time)
         };
 
         let mut prev_debark_stop = first_debark_stop;
@@ -277,15 +277,13 @@ where
                 ));
             }
 
-            let board_timeload = data.board_time_of(trip, board_position).ok_or_else(|| {
+            let board_time = data.board_time_of(trip, board_position).ok_or_else(|| {
                 BadJourney::NoBoardTime(vehicle_leg.clone(), VehicleLegIdx::Connection(idx))
             })?;
-            let board_time = board_timeload.0;
 
-            let debark_timeload = data.debark_time_of(trip, debark_position).ok_or_else(|| {
+            let debark_time = data.debark_time_of(trip, debark_position).ok_or_else(|| {
                 BadJourney::NoDebarkTime(vehicle_leg.clone(), VehicleLegIdx::Connection(idx))
             })?;
-            let debark_time = debark_timeload.0;
 
             let board_stop = data.stop_of(board_position, &mission);
             let debark_stop = data.stop_of(debark_position, &mission);
@@ -323,7 +321,6 @@ where
     fn first_vehicle_board_time(&self, data: &Data) -> SecondsSinceDatasetUTCStart {
         data.board_time_of(&self.first_vehicle.trip, &self.first_vehicle.board_position)
             .unwrap()
-            .0
     }
 
     fn last_vehicle_leg(&self) -> &VehicleLeg<Data> {
@@ -336,8 +333,7 @@ where
     fn last_vehicle_debark_time(&self, data: &Data) -> SecondsSinceDatasetUTCStart {
         let last_vehicle_leg = self.last_vehicle_leg();
         data.debark_time_of(&last_vehicle_leg.trip, &last_vehicle_leg.debark_position)
-            .unwrap()
-            .0 //unwrap is safe because of checks that happens during Self construction
+            .unwrap() //unwrap is safe because of checks that happens during Self construction
     }
 
     pub fn last_vehicle_debark_datetime(&self, data: &Data) -> NaiveDateTime {
@@ -471,13 +467,11 @@ where
 
         let board_time = data
             .board_time_of(trip, &vehicle_leg.board_position)
-            .unwrap()
-            .0;
+            .unwrap();
         let board_datetime = data.to_naive_datetime(board_time);
         let debark_time = data
             .debark_time_of(trip, &vehicle_leg.debark_position)
-            .unwrap()
-            .0;
+            .unwrap();
         let debark_datetime = data.to_naive_datetime(debark_time);
 
         let from_datetime = Self::write_date(&board_datetime);
@@ -553,12 +547,10 @@ impl<Data: DataTrait> Journey<Data> {
         //unwraps below are safe because of checks that happens during Self::new()
         let board_time = data
             .board_time_of(trip, &vehicle_leg.board_position)
-            .unwrap()
-            .0;
+            .unwrap();
         let debark_time = data
             .debark_time_of(trip, &vehicle_leg.debark_position)
-            .unwrap()
-            .0;
+            .unwrap();
 
         let from_datetime = data.to_naive_datetime(board_time);
         let to_datetime = data.to_naive_datetime(debark_time);
@@ -584,8 +576,7 @@ impl<Data: DataTrait> Journey<Data> {
         let prev_trip = &prev_vehicle_leg.trip;
         let prev_debark_time = data
             .debark_time_of(prev_trip, &prev_vehicle_leg.debark_position)
-            .unwrap()
-            .0;
+            .unwrap();
         let from_datetime = data.to_naive_datetime(prev_debark_time);
 
         let (transfer, _) = &self.connections[connection_idx];

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -230,7 +230,7 @@ pub fn solve_schedule_request(
                         }
                         let vehicle_date = data.day_of(&trip);
                         let time = data.board_time_of(&trip, &position).map(
-                            |(second_since_dataset_start, _)| {
+                            |second_since_dataset_start| {
                                 data.calendar()
                                     .to_naive_datetime(second_since_dataset_start)
                             },
@@ -264,7 +264,7 @@ pub fn solve_schedule_request(
                         }
                         let vehicle_date = data.day_of(&trip);
                         let time = data.debark_time_of(&trip, &position).map(
-                            |(second_since_dataset_start, _)| {
+                            |second_since_dataset_start| {
                                 data.calendar()
                                     .to_naive_datetime(second_since_dataset_start)
                             },

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -214,44 +214,56 @@ where
         }
     }
 
-    pub(super) fn debark_time(
-        &self,
-        vehicle: &Vehicle,
-        position: &Position,
-    ) -> Option<(&Time, &Load)> {
+    pub(super) fn debark_time(&self, vehicle: &Vehicle, position: &Position) -> Option<&Time> {
         assert!(vehicle.timetable == position.timetable);
-        let timetable_data = self.timetable_data(&vehicle.timetable);
-        let time = timetable_data.debark_time(vehicle.idx, position.idx)?;
-        let load = timetable_data.load_before(vehicle.idx, position.idx);
-        Some((time, load))
+        self.timetable_data(&vehicle.timetable)
+            .debark_time(vehicle.idx, position.idx)
     }
 
-    pub(super) fn board_time(
-        &self,
-        vehicle: &Vehicle,
-        position: &Position,
-    ) -> Option<(&Time, &Load)> {
+    pub(super) fn debark_load(&self, vehicle: &Vehicle, position: &Position) -> Option<&Load> {
         assert!(vehicle.timetable == position.timetable);
-        let timetable_data = self.timetable_data(&vehicle.timetable);
-        let time = timetable_data.board_time(vehicle.idx, position.idx)?;
-        let load = timetable_data.load_after(vehicle.idx, position.idx);
-        Some((time, load))
+        let load = self
+            .timetable_data(&vehicle.timetable)
+            .load_before(vehicle.idx, position.idx);
+        Some(load)
     }
 
-    pub(super) fn arrival_time(&self, vehicle: &Vehicle, position: &Position) -> (&Time, &Load) {
+    pub(super) fn board_time(&self, vehicle: &Vehicle, position: &Position) -> Option<&Time> {
         assert!(vehicle.timetable == position.timetable);
-        let timetable_data = self.timetable_data(&vehicle.timetable);
-        let time = timetable_data.arrival_time(vehicle.idx, position.idx);
-        let load = timetable_data.load_before(vehicle.idx, position.idx);
-        (time, load)
+        self.timetable_data(&vehicle.timetable)
+            .board_time(vehicle.idx, position.idx)
     }
 
-    pub(super) fn departure_time(&self, vehicle: &Vehicle, position: &Position) -> (&Time, &Load) {
+    pub(super) fn board_load(&self, vehicle: &Vehicle, position: &Position) -> Option<&Load> {
         assert!(vehicle.timetable == position.timetable);
-        let timetable_data = self.timetable_data(&vehicle.timetable);
-        let time = timetable_data.departure_time(vehicle.idx, position.idx);
-        let load = timetable_data.load_after(vehicle.idx, position.idx);
-        (time, load)
+        let load = self
+            .timetable_data(&vehicle.timetable)
+            .load_after(vehicle.idx, position.idx);
+        Some(load)
+    }
+
+    pub(super) fn arrival_time(&self, vehicle: &Vehicle, position: &Position) -> &Time {
+        assert!(vehicle.timetable == position.timetable);
+        self.timetable_data(&vehicle.timetable)
+            .arrival_time(vehicle.idx, position.idx)
+    }
+
+    pub(super) fn arrival_load(&self, vehicle: &Vehicle, position: &Position) -> &Load {
+        assert!(vehicle.timetable == position.timetable);
+        self.timetable_data(&vehicle.timetable)
+            .load_before(vehicle.idx, position.idx)
+    }
+
+    pub(super) fn departure_time(&self, vehicle: &Vehicle, position: &Position) -> &Time {
+        assert!(vehicle.timetable == position.timetable);
+        self.timetable_data(&vehicle.timetable)
+            .departure_time(vehicle.idx, position.idx)
+    }
+
+    pub(super) fn departure_load(&self, vehicle: &Vehicle, position: &Position) -> &Load {
+        assert!(vehicle.timetable == position.timetable);
+        self.timetable_data(&vehicle.timetable)
+            .load_after(vehicle.idx, position.idx)
     }
 
     pub(super) fn earliest_filtered_vehicle_to_board<Filter>(

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -220,26 +220,10 @@ where
             .debark_time(vehicle.idx, position.idx)
     }
 
-    pub(super) fn debark_load(&self, vehicle: &Vehicle, position: &Position) -> Option<&Load> {
-        assert!(vehicle.timetable == position.timetable);
-        let load = self
-            .timetable_data(&vehicle.timetable)
-            .load_before(vehicle.idx, position.idx);
-        Some(load)
-    }
-
     pub(super) fn board_time(&self, vehicle: &Vehicle, position: &Position) -> Option<&Time> {
         assert!(vehicle.timetable == position.timetable);
         self.timetable_data(&vehicle.timetable)
             .board_time(vehicle.idx, position.idx)
-    }
-
-    pub(super) fn board_load(&self, vehicle: &Vehicle, position: &Position) -> Option<&Load> {
-        assert!(vehicle.timetable == position.timetable);
-        let load = self
-            .timetable_data(&vehicle.timetable)
-            .load_after(vehicle.idx, position.idx);
-        Some(load)
     }
 
     pub(super) fn arrival_time(&self, vehicle: &Vehicle, position: &Position) -> &Time {
@@ -248,7 +232,7 @@ where
             .arrival_time(vehicle.idx, position.idx)
     }
 
-    pub(super) fn arrival_load(&self, vehicle: &Vehicle, position: &Position) -> &Load {
+    pub(super) fn load_before(&self, vehicle: &Vehicle, position: &Position) -> &Load {
         assert!(vehicle.timetable == position.timetable);
         self.timetable_data(&vehicle.timetable)
             .load_before(vehicle.idx, position.idx)
@@ -260,7 +244,7 @@ where
             .departure_time(vehicle.idx, position.idx)
     }
 
-    pub(super) fn departure_load(&self, vehicle: &Vehicle, position: &Position) -> &Load {
+    pub(super) fn load_after(&self, vehicle: &Vehicle, position: &Position) -> &Load {
         assert!(vehicle.timetable == position.timetable);
         self.timetable_data(&vehicle.timetable)
             .load_after(vehicle.idx, position.idx)

--- a/src/timetables/timetable_data.rs
+++ b/src/timetables/timetable_data.rs
@@ -324,7 +324,7 @@ where
     }
 
     // Try to insert the trip in this timetable
-    // Returns `true` if insertion was succesfull, `false` otherwise
+    // Returns `true` if insertion was successfull, `false` otherwise
     pub(super) fn try_insert<BoardTimes, DebarkTimes, Loads>(
         &mut self,
         board_times: BoardTimes,

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -154,8 +154,8 @@ impl UTCTimetables {
         calendar.compose_utc(&trip.day, time_in_day)
     }
 
-    pub fn arrival_load_of(&self, trip: &Trip, position: &Position) -> Load {
-        *self.timetables.arrival_load(&trip.vehicle, position)
+    pub fn load_before(&self, trip: &Trip, position: &Position) -> Load {
+        *self.timetables.load_before(&trip.vehicle, position)
     }
 
     pub fn departure_time_of(
@@ -168,8 +168,8 @@ impl UTCTimetables {
         calendar.compose_utc(&trip.day, time_in_day)
     }
 
-    pub fn departure_load_of(&self, trip: &Trip, position: &Position) -> Load {
-        *self.timetables.departure_load(&trip.vehicle, position)
+    pub fn load_after(&self, trip: &Trip, position: &Position) -> Load {
+        *self.timetables.load_after(&trip.vehicle, position)
     }
 
     pub fn debark_time_of(
@@ -187,12 +187,6 @@ impl UTCTimetables {
             })
     }
 
-    pub fn debark_load_of(&self, trip: &Trip, position: &Position) -> Option<Load> {
-        self.timetables
-            .debark_load(&trip.vehicle, position)
-            .copied()
-    }
-
     pub fn board_time_of(
         &self,
         trip: &Trip,
@@ -206,10 +200,6 @@ impl UTCTimetables {
                 let time = calendar.compose_utc(day, time_in_day);
                 time
             })
-    }
-
-    pub fn board_load_of(&self, trip: &Trip, position: &Position) -> Option<Load> {
-        self.timetables.board_load(&trip.vehicle, position).copied()
     }
 
     pub fn earliest_trip_to_board_at(
@@ -274,7 +264,7 @@ impl UTCTimetables {
             if let Some(vehicle) = has_vehicle {
                 let arrival_time_in_day_at_next_stop =
                     self.timetables.arrival_time(&vehicle, &next_position);
-                let load = self.timetables.arrival_load(&vehicle, &next_position);
+                let load = self.timetables.load_before(&vehicle, &next_position);
                 let arrival_time_at_next_stop =
                     calendar.compose_utc(&waiting_day, arrival_time_in_day_at_next_stop);
                 if let Some((_, _, best_arrival_time, best_load)) =

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -149,10 +149,13 @@ impl UTCTimetables {
         trip: &Trip,
         position: &Position,
         calendar: &Calendar,
-    ) -> (SecondsSinceDatasetUTCStart, Load) {
-        let (time_in_day, load) = self.timetables.arrival_time(&trip.vehicle, position);
-        let time_utc = calendar.compose_utc(&trip.day, time_in_day);
-        (time_utc, *load)
+    ) -> SecondsSinceDatasetUTCStart {
+        let time_in_day = self.timetables.arrival_time(&trip.vehicle, position);
+        calendar.compose_utc(&trip.day, time_in_day)
+    }
+
+    pub fn arrival_load_of(&self, trip: &Trip, position: &Position) -> Load {
+        *self.timetables.arrival_load(&trip.vehicle, position)
     }
 
     pub fn departure_time_of(
@@ -160,10 +163,13 @@ impl UTCTimetables {
         trip: &Trip,
         position: &Position,
         calendar: &Calendar,
-    ) -> (SecondsSinceDatasetUTCStart, Load) {
-        let (time_in_day, load) = self.timetables.departure_time(&trip.vehicle, position);
-        let time_utc = calendar.compose_utc(&trip.day, time_in_day);
-        (time_utc, *load)
+    ) -> SecondsSinceDatasetUTCStart {
+        let time_in_day = self.timetables.departure_time(&trip.vehicle, position);
+        calendar.compose_utc(&trip.day, time_in_day)
+    }
+
+    pub fn departure_load_of(&self, trip: &Trip, position: &Position) -> Load {
+        *self.timetables.departure_load(&trip.vehicle, position)
     }
 
     pub fn debark_time_of(
@@ -171,13 +177,20 @@ impl UTCTimetables {
         trip: &Trip,
         position: &Position,
         calendar: &Calendar,
-    ) -> Option<(SecondsSinceDatasetUTCStart, Load)> {
-        let has_timeload_in_day = self.timetables.debark_time(&trip.vehicle, position);
-        has_timeload_in_day.map(|(time_in_day, load)| {
-            let day = &trip.day;
-            let time = calendar.compose_utc(day, time_in_day);
-            (time, *load)
-        })
+    ) -> Option<SecondsSinceDatasetUTCStart> {
+        self.timetables
+            .debark_time(&trip.vehicle, position)
+            .map(|time_in_day| {
+                let day = &trip.day;
+                let time = calendar.compose_utc(day, time_in_day);
+                time
+            })
+    }
+
+    pub fn debark_load_of(&self, trip: &Trip, position: &Position) -> Option<Load> {
+        self.timetables
+            .debark_load(&trip.vehicle, position)
+            .copied()
     }
 
     pub fn board_time_of(
@@ -185,13 +198,18 @@ impl UTCTimetables {
         trip: &Trip,
         position: &Position,
         calendar: &Calendar,
-    ) -> Option<(SecondsSinceDatasetUTCStart, Load)> {
-        let has_timeload_in_day = self.timetables.board_time(&trip.vehicle, position);
-        has_timeload_in_day.map(|(time_in_day, load)| {
-            let day = &trip.day;
-            let time = calendar.compose_utc(day, time_in_day);
-            (time, *load)
-        })
+    ) -> Option<SecondsSinceDatasetUTCStart> {
+        self.timetables
+            .board_time(&trip.vehicle, position)
+            .map(|time_in_day| {
+                let day = &trip.day;
+                let time = calendar.compose_utc(day, time_in_day);
+                time
+            })
+    }
+
+    pub fn board_load_of(&self, trip: &Trip, position: &Position) -> Option<Load> {
+        self.timetables.board_load(&trip.vehicle, position).copied()
     }
 
     pub fn earliest_trip_to_board_at(
@@ -254,8 +272,9 @@ impl UTCTimetables {
                 },
             );
             if let Some(vehicle) = has_vehicle {
-                let (arrival_time_in_day_at_next_stop, load) =
+                let arrival_time_in_day_at_next_stop =
                     self.timetables.arrival_time(&vehicle, &next_position);
+                let load = self.timetables.arrival_load(&vehicle, &next_position);
                 let arrival_time_at_next_stop =
                     calendar.compose_utc(&waiting_day, arrival_time_in_day_at_next_stop);
                 if let Some((_, _, best_arrival_time, best_load)) =

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -182,10 +182,6 @@ impl data_interface::Data for TransitData {
             .board_time_of(trip, position, &self.calendar)
     }
 
-    fn board_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load> {
-        self.timetables.board_load_of(trip, position)
-    }
-
     fn debark_time_of(
         &self,
         trip: &Self::Trip,
@@ -193,10 +189,6 @@ impl data_interface::Data for TransitData {
     ) -> Option<SecondsSinceDatasetUTCStart> {
         self.timetables
             .debark_time_of(trip, position, &self.calendar)
-    }
-
-    fn debark_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load> {
-        self.timetables.debark_load_of(trip, position)
     }
 
     fn arrival_time_of(
@@ -208,8 +200,8 @@ impl data_interface::Data for TransitData {
             .arrival_time_of(trip, position, &self.calendar)
     }
 
-    fn arrival_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
-        self.timetables.arrival_load_of(trip, position)
+    fn load_before(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
+        self.timetables.load_before(trip, position)
     }
 
     fn departure_time_of(
@@ -221,8 +213,8 @@ impl data_interface::Data for TransitData {
             .departure_time_of(trip, position, &self.calendar)
     }
 
-    fn departure_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
-        self.timetables.departure_load_of(trip, position)
+    fn load_after(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
+        self.timetables.load_after(trip, position)
     }
 
     fn transfer_from_to_stop(&self, transfer: &Self::Transfer) -> (Self::Stop, Self::Stop) {

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -177,36 +177,52 @@ impl data_interface::Data for TransitData {
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> Option<(SecondsSinceDatasetUTCStart, Load)> {
+    ) -> Option<SecondsSinceDatasetUTCStart> {
         self.timetables
             .board_time_of(trip, position, &self.calendar)
+    }
+
+    fn board_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load> {
+        self.timetables.board_load_of(trip, position)
     }
 
     fn debark_time_of(
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> Option<(SecondsSinceDatasetUTCStart, Load)> {
+    ) -> Option<SecondsSinceDatasetUTCStart> {
         self.timetables
             .debark_time_of(trip, position, &self.calendar)
+    }
+
+    fn debark_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load> {
+        self.timetables.debark_load_of(trip, position)
     }
 
     fn arrival_time_of(
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> (SecondsSinceDatasetUTCStart, Load) {
+    ) -> SecondsSinceDatasetUTCStart {
         self.timetables
             .arrival_time_of(trip, position, &self.calendar)
+    }
+
+    fn arrival_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
+        self.timetables.arrival_load_of(trip, position)
     }
 
     fn departure_time_of(
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> (SecondsSinceDatasetUTCStart, Load) {
+    ) -> SecondsSinceDatasetUTCStart {
         self.timetables
             .departure_time_of(trip, position, &self.calendar)
+    }
+
+    fn departure_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
+        self.timetables.departure_load_of(trip, position)
     }
 
     fn transfer_from_to_stop(&self, transfer: &Self::Transfer) -> (Self::Stop, Self::Stop) {

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -85,28 +85,38 @@ pub trait Data: TransitTypes {
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> Option<(SecondsSinceDatasetUTCStart, Load)>;
+    ) -> Option<SecondsSinceDatasetUTCStart>;
+    // Panics if `position` is not valid for `trip`
+    fn board_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load>;
     // Panics if `position` is not valid for `trip`
     // None if `trip` does not allows debark at `stop_idx`
     fn debark_time_of(
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> Option<(SecondsSinceDatasetUTCStart, Load)>;
+    ) -> Option<SecondsSinceDatasetUTCStart>;
+    // Panics if `position` is not valid for `trip`
+    fn debark_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load>;
 
     // Panics if `trip` does not go through `position`
     fn arrival_time_of(
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> (SecondsSinceDatasetUTCStart, Load);
+    ) -> SecondsSinceDatasetUTCStart;
+
+    // Panics if `trip` does not go through `position`
+    fn arrival_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load;
 
     // Panics if `trip` does not go through `position`
     fn departure_time_of(
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> (SecondsSinceDatasetUTCStart, Load);
+    ) -> SecondsSinceDatasetUTCStart;
+
+    // Panics if `trip` does not go through `position`
+    fn departure_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load;
 
     fn transfer_from_to_stop(&self, transfer: &Self::Transfer) -> (Self::Stop, Self::Stop);
     fn transfer_duration(&self, transfer: &Self::Transfer) -> PositiveDuration;

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -87,16 +87,12 @@ pub trait Data: TransitTypes {
         position: &Self::Position,
     ) -> Option<SecondsSinceDatasetUTCStart>;
     // Panics if `position` is not valid for `trip`
-    fn board_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load>;
-    // Panics if `position` is not valid for `trip`
     // None if `trip` does not allows debark at `stop_idx`
     fn debark_time_of(
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
     ) -> Option<SecondsSinceDatasetUTCStart>;
-    // Panics if `position` is not valid for `trip`
-    fn debark_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load>;
 
     // Panics if `trip` does not go through `position`
     fn arrival_time_of(
@@ -106,7 +102,7 @@ pub trait Data: TransitTypes {
     ) -> SecondsSinceDatasetUTCStart;
 
     // Panics if `trip` does not go through `position`
-    fn arrival_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load;
+    fn load_before(&self, trip: &Self::Trip, position: &Self::Position) -> Load;
 
     // Panics if `trip` does not go through `position`
     fn departure_time_of(
@@ -116,7 +112,7 @@ pub trait Data: TransitTypes {
     ) -> SecondsSinceDatasetUTCStart;
 
     // Panics if `trip` does not go through `position`
-    fn departure_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load;
+    fn load_after(&self, trip: &Self::Trip, position: &Self::Position) -> Load;
 
     fn transfer_from_to_stop(&self, transfer: &Self::Transfer) -> (Self::Stop, Self::Stop);
     fn transfer_duration(&self, transfer: &Self::Transfer) -> PositiveDuration;

--- a/src/transit_data_filtered.rs
+++ b/src/transit_data_filtered.rs
@@ -197,7 +197,7 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> Option<(SecondsSinceDatasetUTCStart, Load)> {
+    ) -> Option<SecondsSinceDatasetUTCStart> {
         let mission = self.mission_of(trip);
         let stop = self.stop_of(position, &mission);
 
@@ -208,11 +208,22 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         }
     }
 
+    fn board_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load> {
+        let mission = self.mission_of(trip);
+        let stop = self.stop_of(position, &mission);
+
+        if self.is_stop_allowed(&stop) {
+            self.transit_data.board_load_of(trip, position)
+        } else {
+            None
+        }
+    }
+
     fn debark_time_of(
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> Option<(SecondsSinceDatasetUTCStart, Load)> {
+    ) -> Option<SecondsSinceDatasetUTCStart> {
         let mission = self.mission_of(trip);
         let stop = self.stop_of(position, &mission);
 
@@ -223,20 +234,39 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         }
     }
 
+    fn debark_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load> {
+        let mission = self.mission_of(trip);
+        let stop = self.stop_of(position, &mission);
+
+        if self.is_stop_allowed(&stop) {
+            self.transit_data.debark_load_of(trip, position)
+        } else {
+            None
+        }
+    }
+
     fn arrival_time_of(
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> (SecondsSinceDatasetUTCStart, Load) {
+    ) -> SecondsSinceDatasetUTCStart {
         self.transit_data.arrival_time_of(trip, position)
+    }
+
+    fn arrival_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
+        self.transit_data.arrival_load_of(trip, position)
     }
 
     fn departure_time_of(
         &self,
         trip: &Self::Trip,
         position: &Self::Position,
-    ) -> (SecondsSinceDatasetUTCStart, Load) {
+    ) -> SecondsSinceDatasetUTCStart {
         self.transit_data.departure_time_of(trip, position)
+    }
+
+    fn departure_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
+        self.transit_data.departure_load_of(trip, position)
     }
 
     fn transfer_from_to_stop(&self, transfer: &Self::Transfer) -> (Self::Stop, Self::Stop) {

--- a/src/transit_data_filtered.rs
+++ b/src/transit_data_filtered.rs
@@ -208,17 +208,6 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         }
     }
 
-    fn board_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load> {
-        let mission = self.mission_of(trip);
-        let stop = self.stop_of(position, &mission);
-
-        if self.is_stop_allowed(&stop) {
-            self.transit_data.board_load_of(trip, position)
-        } else {
-            None
-        }
-    }
-
     fn debark_time_of(
         &self,
         trip: &Self::Trip,
@@ -234,17 +223,6 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         }
     }
 
-    fn debark_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Option<Load> {
-        let mission = self.mission_of(trip);
-        let stop = self.stop_of(position, &mission);
-
-        if self.is_stop_allowed(&stop) {
-            self.transit_data.debark_load_of(trip, position)
-        } else {
-            None
-        }
-    }
-
     fn arrival_time_of(
         &self,
         trip: &Self::Trip,
@@ -253,8 +231,8 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         self.transit_data.arrival_time_of(trip, position)
     }
 
-    fn arrival_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
-        self.transit_data.arrival_load_of(trip, position)
+    fn load_before(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
+        self.transit_data.load_before(trip, position)
     }
 
     fn departure_time_of(
@@ -265,8 +243,8 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         self.transit_data.departure_time_of(trip, position)
     }
 
-    fn departure_load_of(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
-        self.transit_data.departure_load_of(trip, position)
+    fn load_after(&self, trip: &Self::Trip, position: &Self::Position) -> Load {
+        self.transit_data.load_after(trip, position)
     }
 
     fn transfer_from_to_stop(&self, transfer: &Self::Transfer) -> (Self::Stop, Self::Stop) {


### PR DESCRIPTION
For implementing stay-in functionality, we need to split functionality of `time` and `load` in most functions. Stay-in will need to call [that function](https://github.com/hove-io/loki/blob/master/src/timetables/timetable_data.rs#L96-L99) in a situation where `position_idx == 0` which will panic.