### PR TITLE
Timeout on test request

### DIFF
--- a/server/tests/main_test.rs
+++ b/server/tests/main_test.rs
@@ -443,14 +443,25 @@ async fn send_request_and_wait_for_response(
     zmq_endpoint: &str,
     request: navitia_proto::Request,
 ) -> navitia_proto::Response {
+
+    let timeout = std::time::Duration::from_secs(60);
+
     let context = tmq::Context::new();
     let zmq_socket = tmq::request(&context).connect(zmq_endpoint).unwrap();
 
     // cf https://github.com/cetra3/tmq/blob/master/examples/request.rs
     let zmq_message = tmq::Message::from(request.encode_to_vec());
 
-    let recv_socket = zmq_socket.send(zmq_message.into()).await.unwrap();
-    let (mut reply, _) = recv_socket.recv().await.unwrap();
+    let recv_socket = tokio::time::timeout(
+        timeout, 
+        zmq_socket.send(zmq_message.into())
+    ).await.expect("Send to zmq endpoint timed out").unwrap();
+
+    let (mut reply, _) = tokio::time::timeout(
+        timeout, 
+        recv_socket.recv()
+    ).await.expect("Send to zmq endpoint timed out").unwrap();
+
     let reply_payload = reply.pop_back().unwrap();
 
     navitia_proto::Response::decode(&*reply_payload).unwrap()

--- a/server/tests/main_test.rs
+++ b/server/tests/main_test.rs
@@ -460,7 +460,7 @@ async fn send_request_and_wait_for_response(
     let (mut reply, _) = tokio::time::timeout(
         timeout, 
         recv_socket.recv()
-    ).await.expect("Send to zmq endpoint timed out").unwrap();
+    ).await.expect("Receive zmq endpoint timed out").unwrap();
 
     let reply_payload = reply.pop_back().unwrap();
 

--- a/server/tests/main_test.rs
+++ b/server/tests/main_test.rs
@@ -443,7 +443,6 @@ async fn send_request_and_wait_for_response(
     zmq_endpoint: &str,
     request: navitia_proto::Request,
 ) -> navitia_proto::Response {
-
     let timeout = std::time::Duration::from_secs(60);
 
     let context = tmq::Context::new();
@@ -452,15 +451,15 @@ async fn send_request_and_wait_for_response(
     // cf https://github.com/cetra3/tmq/blob/master/examples/request.rs
     let zmq_message = tmq::Message::from(request.encode_to_vec());
 
-    let recv_socket = tokio::time::timeout(
-        timeout, 
-        zmq_socket.send(zmq_message.into())
-    ).await.expect("Send to zmq endpoint timed out").unwrap();
+    let recv_socket = tokio::time::timeout(timeout, zmq_socket.send(zmq_message.into()))
+        .await
+        .expect("Send to zmq endpoint timed out")
+        .unwrap();
 
-    let (mut reply, _) = tokio::time::timeout(
-        timeout, 
-        recv_socket.recv()
-    ).await.expect("Receive zmq endpoint timed out").unwrap();
+    let (mut reply, _) = tokio::time::timeout(timeout, recv_socket.recv())
+        .await
+        .expect("Receive zmq endpoint timed out")
+        .unwrap();
 
     let reply_payload = reply.pop_back().unwrap();
 


### PR DESCRIPTION
When loki fails during one of the integration tests in `server/tests`, the test thread was waiting indefinitely for an answer.
It should now fails if no answer is received before 60s