### PR TITLE
fix artemis launch

### DIFF
--- a/.github/workflows/dockers.yml
+++ b/.github/workflows/dockers.yml
@@ -166,6 +166,7 @@ jobs:
         docker run  \
         --network host \
         -v $PWD:/usr/src/app  \
+        -v /var/run/docker.sock:/var/run/docker.sock \
         -e ARTEMIS_LOG_LEVEL=INFO \
         -e ARTEMIS_USE_LOKI=False   \
         -e ARTEMIS_USE_ARTEMIS_NG=True   \
@@ -181,6 +182,7 @@ jobs:
         docker run  \
         --network host \
         -v $PWD:/usr/src/app  \
+        -v /var/run/docker.sock:/var/run/docker.sock \
         -e ARTEMIS_LOG_LEVEL=INFO \
         -e ARTEMIS_USE_LOKI=True   \
         -e ARTEMIS_USE_ARTEMIS_NG=True   \


### PR DESCRIPTION
Since https://github.com/hove-io/artemis/pull/427 Artemis requires mounting the docker socket into the artemis docker (so that it can [download asgard docker](https://github.com/hove-io/artemis/blob/e8ae85c7c20ca69714c5ddb730a1752d4e89fc29/artemis/base_pytest.py#L134-L136)).

This should fix the CI failure on artemis.