### PR TITLE
Fix transfer duration

### DIFF
--- a/launch/src/solver.rs
+++ b/launch/src/solver.rs
@@ -229,12 +229,12 @@ where
     let request_timer = SystemTime::now();
     engine.compute(request);
     info!(
-        "Journeys computed in {} ms with {} rounds",
+        "Computed {} journeys in {} ms with {} rounds. Tree size : {}",
+        engine.nb_of_journeys(),
         request_timer.elapsed().unwrap().as_millis(),
-        engine.nb_of_rounds()
+        engine.nb_of_rounds(),
+        engine.tree_size(),
     );
-    info!("Nb of journeys found : {}", engine.nb_of_journeys());
-    info!("Tree size : {}", engine.tree_size());
 
     let journeys_iter = engine.responses().filter_map(|pt_journey| {
         request

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -483,7 +483,7 @@ fn solve(
     })?;
     let departure_datetime = loki::NaiveDateTime::from_timestamp(departure_timestamp_i64, 0);
 
-    info!(
+    debug!(
         "Requested timestamp {}, datetime {}",
         departure_timestamp_u64, departure_datetime
     );

--- a/server/src/data_worker.rs
+++ b/server/src/data_worker.rs
@@ -186,6 +186,7 @@ impl DataWorker {
         if let Err(err) = self.reload_chaos().await {
             error!("Error while reloading chaos. {:?}", err);
         }
+        info!("DataWorker completed initial load data.");
 
         let rabbitmq_connect_retry_interval =
             Duration::from_secs(self.config.rabbitmq.connect_retry_interval.total_seconds());
@@ -226,7 +227,7 @@ impl DataWorker {
                     }
                     let result = self.main_loop(&channel).await;
                     error!(
-                        "DataWorker main loop exited. I'll relaunch the worker. {:?} ",
+                        "DataWorker was disconnected from rabbitmq. I'll try to reconnect. {:?} ",
                         result
                     );
                     self.send_status_update(StatusUpdate::RabbitMqDisconnected)?;
@@ -257,7 +258,7 @@ impl DataWorker {
 
         loop {
             tokio::select! {
-                // sends all messages in the buffer every X seconds
+                // apply all messages in the buffer every X seconds
                 _ = interval.tick() => {
                     if ! self.realtime_messages.is_empty() {
                         info!("It's time to apply {} real time messages.", self.realtime_messages.len());

--- a/src/request/arrive_before.rs
+++ b/src/request/arrive_before.rs
@@ -451,7 +451,10 @@ where
 
         for (transfer, vehicle) in journey.connections.iter_mut() {
             // increase time by transfer_duration
-            let transfer_duration = self.transit_data.transfer_duration(transfer);
+            let transfer_duration = self
+                .transit_data
+                .transfer_durations(transfer)
+                .total_duration;
             current_time = current_time + transfer_duration;
 
             let new_debark_time = self._minimize_leg_debark_time(vehicle, current_time)?;

--- a/src/request/depart_after.rs
+++ b/src/request/depart_after.rs
@@ -438,7 +438,10 @@ where
             let new_board_time = self._maximize_leg_board_time(vehicle, current_time)?;
             current_time = new_board_time;
 
-            let transfer_duration = self.transit_data.transfer_duration(transfer);
+            let transfer_duration = self
+                .transit_data
+                .transfer_durations(transfer)
+                .total_duration;
             current_time = current_time - transfer_duration;
         }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -256,7 +256,7 @@ where
 
         for (idx, (transfer, vehicle_leg)) in self.connections.iter().enumerate() {
             let (transfer_from_stop, transfer_to_stop) = data.transfer_from_to_stop(transfer);
-            let transfer_duration = data.transfer_duration(transfer);
+            let transfer_duration = data.transfer_durations(transfer).total_duration;
 
             if !data.is_same_stop(&prev_debark_stop, &transfer_from_stop) {
                 return Err(BadJourney::BadTransferStartStop(
@@ -346,10 +346,10 @@ where
         last_debark_time + self.arrival_fallback_duration
     }
 
-    pub fn total_transfer_duration(&self, data: &Data) -> PositiveDuration {
+    pub fn total_transfer_walking_duration(&self, data: &Data) -> PositiveDuration {
         let mut result = PositiveDuration::zero();
         for (transfer, _) in &self.connections {
-            let transfer_duration = data.transfer_duration(transfer);
+            let transfer_duration = data.transfer_durations(transfer).walking_duration;
             result = result + transfer_duration;
         }
         result
@@ -416,8 +416,8 @@ where
         writeln!(writer, "Arrival : {}", Self::write_date(&arrival_datetime))?;
         writeln!(
             writer,
-            "Transfer duration : {}",
-            self.total_transfer_duration(data)
+            "Transfer walking duration : {}",
+            self.total_transfer_walking_duration(data)
         )?;
         writeln!(writer, "Nb of vehicles : {}", self.nb_of_legs())?;
         writeln!(
@@ -581,7 +581,7 @@ impl<Data: DataTrait> Journey<Data> {
 
         let (transfer, _) = &self.connections[connection_idx];
         let (transfer_from_stop, transfer_to_stop) = data.transfer_from_to_stop(transfer);
-        let transfer_duration = data.transfer_duration(transfer);
+        let transfer_duration = data.transfer_durations(transfer).walking_duration;
         let end_transfer_time = prev_debark_time + transfer_duration;
         let to_datetime = data.to_naive_datetime(end_transfer_time);
         let to_stop_point = data.stop_point_idx(&transfer_to_stop);

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -222,9 +222,9 @@ impl data_interface::Data for TransitData {
         (transfer_data.from_stop, transfer_data.to_stop)
     }
 
-    fn transfer_duration(&self, transfer: &Self::Transfer) -> PositiveDuration {
+    fn transfer_durations(&self, transfer: &Self::Transfer) -> &TransferDurations {
         let transfer_data = &self.transfers_data[transfer.idx];
-        transfer_data.durations.total_duration
+        &transfer_data.durations
     }
 
     fn transfer_idx(&self, transfer: &Self::Transfer) -> TransferIdx {

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -1,7 +1,7 @@
 use crate::{
     loads_data::Load,
     models::{StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
-    time::{PositiveDuration, SecondsSinceDatasetUTCStart},
+    time::SecondsSinceDatasetUTCStart,
 };
 use chrono::{NaiveDate, NaiveDateTime};
 pub use typed_index_collection::Idx;
@@ -115,7 +115,7 @@ pub trait Data: TransitTypes {
     fn load_after(&self, trip: &Self::Trip, position: &Self::Position) -> Load;
 
     fn transfer_from_to_stop(&self, transfer: &Self::Transfer) -> (Self::Stop, Self::Stop);
-    fn transfer_duration(&self, transfer: &Self::Transfer) -> PositiveDuration;
+    fn transfer_durations(&self, transfer: &Self::Transfer) -> &TransferDurations;
     fn transfer_idx(&self, transfer: &Self::Transfer) -> TransferIdx;
 
     fn stay_in_next(&self, trip: &Self::Trip, real_time_level: RealTimeLevel)

--- a/src/transit_data_filtered.rs
+++ b/src/transit_data_filtered.rs
@@ -38,9 +38,9 @@ use crate::{
     filters::Filters,
     loads_data::Load,
     models::{ModelRefs, StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
-    time::{Calendar, PositiveDuration, SecondsSinceDatasetUTCStart},
+    time::{Calendar, SecondsSinceDatasetUTCStart},
     timetables::utc_timetables,
-    transit_data::{self, data_interface, data_iters},
+    transit_data::{self, data_interface, data_iters, TransferDurations},
     RealTimeLevel, TransitData,
 };
 pub use transit_model::objects::{
@@ -251,8 +251,8 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         self.transit_data.transfer_from_to_stop(transfer)
     }
 
-    fn transfer_duration(&self, transfer: &Self::Transfer) -> PositiveDuration {
-        self.transit_data.transfer_duration(transfer)
+    fn transfer_durations(&self, transfer: &Self::Transfer) -> &TransferDurations {
+        self.transit_data.transfer_durations(transfer)
     }
 
     fn transfer_idx(&self, transfer: &Self::Transfer) -> TransferIdx {


### PR DESCRIPTION
Transfer durations in the responses now refers to the walking duration of the transfer (i.e. min_transfer_time [in the spec](https://github.com/hove-io/ntfs-specification/blob/master/ntfs_fr.md#transferstxt-optionnel)).

Before the duration of the transfer in the responses was referring to the total transfer duration (i.e. real_min_transfer_time [in the spec](https://github.com/hove-io/ntfs-specification/blob/master/ntfs_fr.md#transferstxt-optionnel))

Note that we still use the total transfer duration in the algorithm  computing the journeys. 

This fix an inconsistency between kraken (left) and loki (right)
![Screenshot from 2022-07-13 11-29-59](https://user-images.githubusercontent.com/52410095/178703660-f4516dce-755f-4cbe-9188-06d4effeaf25.png)

