### PR TITLE
Simplify earliest/latest vehicle to board/debark

### DIFF
--- a/src/request/arrive_before.rs
+++ b/src/request/arrive_before.rs
@@ -287,7 +287,13 @@ where
     ) -> Option<(Data::Trip, Criteria)> {
         let waiting_time = waiting_criteria.time;
         self.transit_data
-            .latest_trip_that_debark_at(waiting_time, mission, position, self.real_time_level)
+            .latest_trip_that_debark(
+                waiting_time,
+                mission,
+                position,
+                self.real_time_level,
+                |_| true,
+            )
             .map(|(trip, debark_time, load)| {
                 let new_criteria = Criteria {
                     time: debark_time,
@@ -425,7 +431,13 @@ where
         let mission = &self.transit_data.mission_of(trip);
         let (new_trip, _, _) = self
             .transit_data
-            .earliest_trip_to_board_at(board_time, mission, board_position, self.real_time_level)
+            .earliest_trip_to_board(
+                board_time,
+                mission,
+                board_position,
+                self.real_time_level,
+                |_| true,
+            )
             .ok_or_else(|| NoTrip(board_time, mission.clone(), board_position.clone()))?;
         *trip = new_trip;
         let debark_time = self

--- a/src/request/depart_after.rs
+++ b/src/request/depart_after.rs
@@ -265,7 +265,13 @@ where
     ) -> Option<(Data::Trip, Criteria)> {
         let waiting_time = waiting_criteria.time;
         self.transit_data
-            .earliest_trip_to_board_at(waiting_time, mission, position, self.real_time_level)
+            .earliest_trip_to_board(
+                waiting_time,
+                mission,
+                position,
+                self.real_time_level,
+                |_| true,
+            )
             .map(|(trip, arrival_time, load)| {
                 let new_criteria = Criteria {
                     time: arrival_time,
@@ -402,7 +408,13 @@ where
         let mission = &self.transit_data.mission_of(trip);
         let (new_trip, _, _) = self
             .transit_data
-            .latest_trip_that_debark_at(debark_time, mission, debark_position, self.real_time_level)
+            .latest_trip_that_debark(
+                debark_time,
+                mission,
+                debark_position,
+                self.real_time_level,
+                |_| true,
+            )
             .ok_or_else(|| NoTrip(debark_time, mission.clone(), debark_position.clone()))?;
         *trip = new_trip;
         let board_time = self

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -150,8 +150,10 @@ where
             .vehicle_data(vehicle.idx)
     }
 
-    pub(super) fn stoptime_idx(&self, position: &Position) -> usize {
-        position.idx.idx
+    pub(super) fn stoptime_idx(&self, position: &Position) -> StopTimeIdx {
+        StopTimeIdx {
+            idx: position.idx.idx,
+        }
     }
 
     pub(super) fn timetable_of(&self, vehicle: &Vehicle) -> Timetable {

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -87,10 +87,15 @@ pub struct Timetable {
     pub(super) idx: usize,
 }
 
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub(super) struct PositionIdx {
+    pub(super) idx: usize,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Position {
     pub(super) timetable: Timetable,
-    pub(super) idx: usize,
+    pub(super) idx: PositionIdx,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -141,7 +146,7 @@ where
     }
 
     pub(super) fn stoptime_idx(&self, position: &Position) -> usize {
-        position.idx
+        position.idx.idx
     }
 
     pub(super) fn timetable_of(&self, vehicle: &Vehicle) -> Timetable {
@@ -160,14 +165,14 @@ where
         timetable: &Timetable,
     ) -> bool {
         assert!(upstream.timetable == *timetable);
-        upstream.idx < downstream.idx
+        upstream.idx.idx < downstream.idx.idx
     }
 
     pub(super) fn first_position(&self, timetable: &Timetable) -> Position {
         assert!(self.timetable_data(timetable).nb_of_positions() > 0);
         Position {
             timetable: timetable.clone(),
-            idx: 0,
+            idx: PositionIdx { idx: 0 },
         }
     }
 
@@ -176,7 +181,9 @@ where
         assert!(nb_of_positions > 0);
         Position {
             timetable: timetable.clone(),
-            idx: nb_of_positions - 1,
+            idx: PositionIdx {
+                idx: nb_of_positions - 1,
+            },
         }
     }
 
@@ -186,10 +193,11 @@ where
         timetable: &Timetable,
     ) -> Option<Position> {
         assert!(position.timetable == *timetable);
-        if position.idx + 1 < self.timetable_data(&position.timetable).nb_of_positions() {
+        let idx = position.idx.idx;
+        if idx + 1 < self.timetable_data(&position.timetable).nb_of_positions() {
             let result = Position {
                 timetable: position.timetable.clone(),
-                idx: position.idx + 1,
+                idx: PositionIdx { idx: idx + 1 },
             };
             Some(result)
         } else {
@@ -203,10 +211,11 @@ where
         timetable: &Timetable,
     ) -> Option<Position> {
         assert_eq!(position.timetable, *timetable);
-        if position.idx >= 1 {
+        let idx = position.idx.idx;
+        if idx >= 1 {
             let result = Position {
                 timetable: position.timetable.clone(),
-                idx: position.idx - 1,
+                idx: PositionIdx { idx: idx - 1 },
             };
             Some(result)
         } else {

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -98,10 +98,15 @@ pub struct Position {
     pub(super) idx: PositionIdx,
 }
 
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub(super) struct VehicleIdx {
+    pub(super) idx: usize,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Vehicle {
     pub(super) timetable: Timetable,
-    pub(super) idx: usize,
+    pub(super) idx: VehicleIdx,
 }
 
 #[derive(Debug, Clone)]

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -269,7 +269,7 @@ where
             })
     }
 
-    pub(super) fn latest_filtered_vehicle_that_debark<Filter>(
+    pub(super) fn latest_vehicle_that_debark<Filter>(
         &self,
         time: &Time,
         timetable: &Timetable,
@@ -281,7 +281,7 @@ where
     {
         assert_eq!(position.timetable, *timetable);
         self.timetable_data(timetable)
-            .latest_filtered_vehicle_that_debark(time, position.idx, filter)
+            .latest_vehicle_that_debark(time, position.idx, filter)
             .map(|(idx, time)| {
                 let vehicle = Vehicle {
                     timetable: timetable.clone(),

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -250,7 +250,7 @@ where
             .load_after(vehicle.idx, position.idx)
     }
 
-    pub(super) fn earliest_filtered_vehicle_to_board<Filter>(
+    pub(super) fn earliest_vehicle_to_board<Filter>(
         &self,
         waiting_time: &Time,
         timetable: &Timetable,
@@ -262,7 +262,7 @@ where
     {
         assert!(position.timetable == *timetable);
         self.timetable_data(timetable)
-            .earliest_filtered_vehicle_to_board(waiting_time, position.idx, &filter)
+            .earliest_vehicle_to_board(waiting_time, position.idx, &filter)
             .map(|idx| Vehicle {
                 timetable: timetable.clone(),
                 idx,

--- a/src/timetables/generic_timetables.rs
+++ b/src/timetables/generic_timetables.rs
@@ -275,22 +275,16 @@ where
         timetable: &Timetable,
         position: &Position,
         filter: Filter,
-    ) -> Option<(Vehicle, &Time, &Load)>
+    ) -> Option<Vehicle>
     where
         Filter: Fn(&VehicleData) -> bool,
     {
         assert_eq!(position.timetable, *timetable);
         self.timetable_data(timetable)
             .latest_vehicle_that_debark(time, position.idx, filter)
-            .map(|(idx, time)| {
-                let vehicle = Vehicle {
-                    timetable: timetable.clone(),
-                    idx,
-                };
-                let load = self
-                    .timetable_data(timetable)
-                    .load_before(idx, position.idx);
-                (vehicle, time, load)
+            .map(|idx| Vehicle {
+                timetable: timetable.clone(),
+                idx,
             })
     }
 

--- a/src/timetables/timetable_data.rs
+++ b/src/timetables/timetable_data.rs
@@ -503,7 +503,7 @@ where
         Some(nb_of_vehicle)
     }
 
-    pub(super) fn do_insert<BoardTimes, DebarkTimes, Loads>(
+    fn do_insert<BoardTimes, DebarkTimes, Loads>(
         &mut self,
         board_times: BoardTimes,
         debark_times: DebarkTimes,
@@ -569,6 +569,7 @@ where
         combine(board_debark_cmp, loads_cmp)
     }
 
+    // Returns the number of removed entries
     pub(super) fn remove_vehicles<Filter>(&mut self, vehicle_filter: Filter) -> usize
     where
         Filter: Fn(&VehicleData) -> bool,
@@ -664,7 +665,7 @@ fn combine(a: Ordering, b: Ordering) -> Option<Ordering> {
 //    - Some(Less)    if lower[i] <= upper[i] for all i
 //    - Some(Greater) if lower[i] >= upper[i] for all i
 //    - None otherwise (the two vector are not comparable)
-pub(super) fn partial_cmp<Lower, Upper, Value, UpperVal, LowerVal>(
+fn partial_cmp<Lower, Upper, Value, UpperVal, LowerVal>(
     lower: Lower,
     upper: Upper,
 ) -> Option<Ordering>

--- a/src/timetables/timetable_data.rs
+++ b/src/timetables/timetable_data.rs
@@ -114,15 +114,19 @@ where
         &self.vehicle_datas[vehicle_idx]
     }
 
-    // If we are waiting to board a trip at `position` at time ``
+    // If we are waiting to board a trip at `position` at time `waiting_time`
     // return `Some(best_vehicle_idx)`
-    // where `best_vehicle_idx` is the idx of the first Vehicle that can be boarded
-    //  after waiting_time
-    pub(super) fn earliest_vehicle_to_board(
+    // where `best_vehicle_idx` is the idx of the earliest vehicle, among those on which `filter` returns true,
+    // that can be boarded after or at waiting_time
+    pub(super) fn earliest_vehicle_to_board<Filter>(
         &self,
         waiting_time: &Time,
         position_idx: usize,
-    ) -> Option<usize> {
+        filter: Filter,
+    ) -> Option<usize>
+    where
+        Filter: Fn(&VehicleData) -> bool,
+    {
         if !self.can_board(position_idx) {
             return None;
         }
@@ -158,20 +162,6 @@ where
                     .binary_search_by(|time| if time < waiting_time { Less } else { Greater })
                     .unwrap_err()
             };
-
-        Some(first_boardable_vehicle)
-    }
-
-    pub(super) fn earliest_filtered_vehicle_to_board<Filter>(
-        &self,
-        waiting_time: &Time,
-        position_idx: usize,
-        filter: &Filter,
-    ) -> Option<usize>
-    where
-        Filter: Fn(&VehicleData) -> bool,
-    {
-        let first_boardable_vehicle = self.earliest_vehicle_to_board(waiting_time, position_idx)?;
 
         for vehicle_idx in first_boardable_vehicle..self.nb_of_vehicle() {
             let vehicle_data = &self.vehicle_datas[vehicle_idx];

--- a/src/timetables/timetable_data.rs
+++ b/src/timetables/timetable_data.rs
@@ -232,24 +232,22 @@ where
         None
     }
 
-    // Given a `position` and a `time`
-    // return `Some(best_trip_idx)`
-    // where `best_trip_idx` is the idx of the latest vehicle, among those  on which `filter` returns true,
-    // that debark at the subsequent positions at the latest time
+    // Returns `Some(best_vehicle_idx)`
+    // where `best_vehicle_idx` is the idx of the vehicle with the latest debark time, among those on which `filter` returns true,
+    // that can be debarked at `position` before or at `waiting_time`.
+    // Returns None if no vehicle can be debarked at `position` before or at `waiting_time`.
     pub(super) fn latest_vehicle_that_debark<Filter>(
         &self,
         waiting_time: &Time,
         position_idx: usize,
         filter: Filter,
-    ) -> Option<(usize, &Time)>
+    ) -> Option<usize>
     where
         Filter: Fn(&VehicleData) -> bool,
     {
         if !self.can_debark(position_idx) {
             return None;
         }
-        // we should not be able to debark at the first position
-        assert!(position_idx > 0);
 
         let nb_of_vehicles = self.debark_times_by_position[position_idx].len();
         if nb_of_vehicles == 0 {
@@ -287,9 +285,7 @@ where
         for vehicle_idx in (0..after_last_debarkable_vehicle).rev() {
             let vehicle_data = &self.vehicle_datas[vehicle_idx];
             if filter(vehicle_data) {
-                let departure_time_at_previous_position =
-                    self.departure_time(vehicle_idx, position_idx - 1);
-                return Some((vehicle_idx, departure_time_at_previous_position));
+                return Some(vehicle_idx);
             }
         }
         None

--- a/src/timetables/timetable_data.rs
+++ b/src/timetables/timetable_data.rs
@@ -114,10 +114,10 @@ where
         &self.vehicle_datas[vehicle_idx]
     }
 
-    // If we are waiting to board a trip at `position` at time `waiting_time`
-    // return `Some(best_vehicle_idx)`
-    // where `best_vehicle_idx` is the idx of the earliest vehicle, among those on which `filter` returns true,
-    // that can be boarded after or at waiting_time
+    // Returns `Some(best_vehicle_idx)`
+    // where `best_vehicle_idx` is the idx of the vehicle with the earliest board time, among those on which `filter` returns true,
+    // that can be boarded at `position` after or at `waiting_time`.
+    // Returns None if no vehicle can be boarded at `position` after or at `waiting_time`.
     pub(super) fn earliest_vehicle_to_board<Filter>(
         &self,
         waiting_time: &Time,
@@ -173,15 +173,19 @@ where
         None
     }
 
-    // If we are waiting to board a trip at `position` at time ``
-    // return `Some(best_vehicle_idx)`
-    // where `best_vehicle_idx` is the idx of the first Vehicle that can be debarked
-    //  after waiting_time
-    pub(super) fn earliest_vehicle_to_debark(
+    // Returns `Some(best_vehicle_idx)`
+    // where `best_vehicle_idx` is the idx of the vehicle with the earliest debark time, among those on which `filter` returns true,
+    // that can be debarked at `position` after or at `waiting_time`.
+    // Returns None if no vehicle can be debarked at `position` after or at `waiting_time`.
+    pub(super) fn earliest_vehicle_that_debark<Filter>(
         &self,
         waiting_time: &Time,
         position_idx: usize,
-    ) -> Option<usize> {
+        filter: Filter,
+    ) -> Option<usize>
+    where
+        Filter: Fn(&VehicleData) -> bool,
+    {
         if !self.can_debark(position_idx) {
             return None;
         }
@@ -196,35 +200,43 @@ where
             return None;
         }
 
-        let first_vehicle = if waiting_time <= &self.debark_times_by_position[position_idx][0] {
-            0
-        } else {
-            // We are looking for the smallest index in slice (debark_times_by_position here)
-            // such that slice(idx) >= waiting_time.
-            // In order to do so we use binary_search_by with the comparator
-            // function F : |time| if time < waiting_time { Less } else { Greater }
-            // binary_search_by on slice with a comparator function F will return :
-            // - Ok(idx) if there a idx such that F(slice(idx)) == Equal
-            // - Err(idx) otherwise. In this case it means that F(slice(idx)) == Greater,
-            // and F(slice(idx-1)) == Less if idx >= 1
-            // Since our comparator will never return Equal,
-            // binary_search_by will always return Err(idx).
-            // So when we obtain Err(idx) it means that slice(idx) >= waiting_time
-            // And slice(idx-1) < waiting_time
-            // So idx is the smallest index such that slice(idx) >= waiting_time
-            self.debark_times_by_position[position_idx]
-                .binary_search_by(|time| if time < waiting_time { Less } else { Greater })
-                .unwrap_err()
-        };
+        let first_debarkable_vehicle =
+            if waiting_time <= &self.debark_times_by_position[position_idx][0] {
+                0
+            } else {
+                // We are looking for the smallest index in slice (debark_times_by_position here)
+                // such that slice(idx) >= waiting_time.
+                // In order to do so we use binary_search_by with the comparator
+                // function F : |time| if time < waiting_time { Less } else { Greater }
+                // binary_search_by on slice with a comparator function F will return :
+                // - Ok(idx) if there a idx such that F(slice(idx)) == Equal
+                // - Err(idx) otherwise. In this case it means that F(slice(idx)) == Greater,
+                // and F(slice(idx-1)) == Less if idx >= 1
+                // Since our comparator will never return Equal,
+                // binary_search_by will always return Err(idx).
+                // So when we obtain Err(idx) it means that slice(idx) >= waiting_time
+                // And slice(idx-1) < waiting_time
+                // So idx is the smallest index such that slice(idx) >= waiting_time
+                self.debark_times_by_position[position_idx]
+                    .binary_search_by(|time| if time < waiting_time { Less } else { Greater })
+                    .unwrap_err()
+            };
 
-        Some(first_vehicle)
+        for vehicle_idx in first_debarkable_vehicle..self.nb_of_vehicle() {
+            let vehicle_data = &self.vehicle_datas[vehicle_idx];
+            let debark_time = &self.debark_times_by_position[position_idx][vehicle_idx];
+            if filter(vehicle_data) && waiting_time <= debark_time {
+                return Some(vehicle_idx);
+            }
+        }
+        None
     }
 
     // Given a `position` and a `time`
     // return `Some(best_trip_idx)`
-    // where `best_trip_idx` is the idx of the trip, among those trip on which `filter` returns true,
+    // where `best_trip_idx` is the idx of the latest vehicle, among those  on which `filter` returns true,
     // that debark at the subsequent positions at the latest time
-    pub(super) fn latest_filtered_vehicle_that_debark<Filter>(
+    pub(super) fn latest_vehicle_that_debark<Filter>(
         &self,
         waiting_time: &Time,
         position_idx: usize,

--- a/src/timetables/timetable_iters.rs
+++ b/src/timetables/timetable_iters.rs
@@ -34,7 +34,9 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use super::generic_timetables::{GenericTimetables, Position, Timetable, TimetableData, Vehicle};
+use super::generic_timetables::{
+    GenericTimetables, Position, PositionIdx, Timetable, TimetableData, Vehicle,
+};
 use std::{fmt::Debug, iter::Map, ops::Range};
 
 pub type TimetableIter = Map<Range<usize>, fn(usize) -> Timetable>;
@@ -109,7 +111,7 @@ impl Iterator for PositionsIter {
     fn next(&mut self) -> Option<Self::Item> {
         self.position_idxs.next().map(|idx| Position {
             timetable: self.timetable.clone(),
-            idx,
+            idx: PositionIdx { idx },
         })
     }
 }

--- a/src/timetables/timetable_iters.rs
+++ b/src/timetables/timetable_iters.rs
@@ -35,7 +35,7 @@
 // www.navitia.io
 
 use super::generic_timetables::{
-    GenericTimetables, Position, PositionIdx, Timetable, TimetableData, Vehicle,
+    GenericTimetables, Position, PositionIdx, Timetable, TimetableData, Vehicle, VehicleIdx,
 };
 use std::{fmt::Debug, iter::Map, ops::Range};
 
@@ -136,7 +136,7 @@ impl Iterator for VehicleIter {
     fn next(&mut self) -> Option<Self::Item> {
         self.vehicle_idxs.next().map(|idx| Vehicle {
             timetable: self.timetable.clone(),
-            idx,
+            idx: VehicleIdx { idx },
         })
     }
 }

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -332,7 +332,7 @@ impl UTCTimetables {
             Load,
         )> = None;
         for (waiting_day, waiting_time_in_day) in decompositions {
-            let has_vehicle = self.timetables.latest_filtered_vehicle_that_debark(
+            let has_vehicle = self.timetables.latest_vehicle_that_debark(
                 &waiting_time_in_day,
                 mission,
                 position,
@@ -798,7 +798,7 @@ impl<'a, const BOARD_TIMES: bool> TripsBetween<'a, BOARD_TIMES> {
                     .unwrap_or_else(|| timetable_data.nb_of_vehicle())
             } else {
                 timetable_data
-                    .earliest_vehicle_to_debark(&from_time_in_day, position_idx)
+                    .earliest_vehicle_that_debark(&from_time_in_day, position_idx, |_| true)
                     .unwrap_or_else(|| timetable_data.nb_of_vehicle())
             };
 
@@ -917,7 +917,11 @@ impl<'a, const BOARD_TIMES: bool> Iterator for TripsBetween<'a, BOARD_TIMES> {
                             .unwrap_or_else(|| timetable_data.nb_of_vehicle());
                     } else {
                         self.current_vehicle_idx = timetable_data
-                            .earliest_vehicle_to_debark(&from_time_in_day, self.position_idx)
+                            .earliest_vehicle_that_debark(
+                                &from_time_in_day,
+                                self.position_idx,
+                                |_| true,
+                            )
                             .unwrap_or_else(|| timetable_data.nb_of_vehicle());
                     }
 

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -48,7 +48,7 @@ use crate::{
 
 use super::{
     day_to_timetable::LocalZone,
-    generic_timetables::{GenericTimetables, Vehicle},
+    generic_timetables::{GenericTimetables, PositionIdx, Vehicle},
     timetable_iters::{PositionsIter, TimetableIter},
 };
 use crate::time::{
@@ -711,7 +711,7 @@ pub struct TripsBetween<'a, const BOARD_TIMES: bool> {
     days_patterns: &'a DaysPatterns,
     calendar: &'a Calendar,
     mission: Mission,
-    position_idx: usize,
+    position_idx: PositionIdx,
     from_time: SecondsSinceDatasetUTCStart,
     until_time: SecondsSinceDatasetUTCStart,
 
@@ -728,7 +728,7 @@ impl<'a, const BOARD_TIMES: bool> TripsBetween<'a, BOARD_TIMES> {
         days_patterns: &'a DaysPatterns,
         calendar: &'a Calendar,
         mission: Mission,
-        position_idx: usize,
+        position_idx: PositionIdx,
         from_time: SecondsSinceDatasetUTCStart,
         until_time: SecondsSinceDatasetUTCStart,
     ) -> Self {
@@ -816,9 +816,9 @@ impl<'a, const BOARD_TIMES: bool> Iterator for TripsBetween<'a, BOARD_TIMES> {
                 let vehicle_idx = self.current_vehicle_idx;
                 self.current_vehicle_idx += 1;
                 let time = if BOARD_TIMES {
-                    &timetable_data.board_times_by_position[self.position_idx][vehicle_idx]
+                    &timetable_data.board_times_by_position[self.position_idx.idx][vehicle_idx]
                 } else {
-                    &timetable_data.debark_times_by_position[self.position_idx][vehicle_idx]
+                    &timetable_data.debark_times_by_position[self.position_idx.idx][vehicle_idx]
                 };
 
                 if *time > self.current_until_time_in_day {

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -315,7 +315,7 @@ impl UTCTimetables {
                 let departure_time_at_previous_stop =
                     calendar.compose_utc(&waiting_day, departure_time_in_day_at_previous_stop);
 
-                let load = self.timetables.load_before(&vehicle, &position);
+                let load = self.timetables.load_before(&vehicle, position);
                 if let Some((_, _, best_departure_time, best_load)) =
                     &best_vehicle_day_and_its_departure_time_at_previous_position
                 {

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -734,6 +734,7 @@ impl<'a, const BOARD_TIMES: bool> TripsBetween<'a, BOARD_TIMES> {
     ) -> Self {
         let timetable_data = utc_timetables.timetables.timetable_data(&mission);
         let nb_of_vehicle = timetable_data.nb_of_vehicle();
+        let after_last_vehicle_idx = VehicleIdx { idx: nb_of_vehicle };
 
         let empty_iterator = Self {
             utc_timetables,
@@ -762,11 +763,11 @@ impl<'a, const BOARD_TIMES: bool> TripsBetween<'a, BOARD_TIMES> {
             let current_vehicle_idx = if BOARD_TIMES {
                 timetable_data
                     .earliest_vehicle_to_board(&from_time_in_day, position_idx, |_| true)
-                    .unwrap_or_else(|| VehicleIdx { idx: nb_of_vehicle })
+                    .unwrap_or(after_last_vehicle_idx)
             } else {
                 timetable_data
                     .earliest_vehicle_that_debark(&from_time_in_day, position_idx, |_| true)
-                    .unwrap_or_else(|| VehicleIdx { idx: nb_of_vehicle })
+                    .unwrap_or(after_last_vehicle_idx)
             };
 
             let until_time_in_day = match calendar.decompose_utc(until_time, from_day) {
@@ -812,6 +813,7 @@ impl<'a, const BOARD_TIMES: bool> Iterator for TripsBetween<'a, BOARD_TIMES> {
 
             let timetable_data = self.utc_timetables.timetables.timetable_data(&self.mission);
             let nb_of_vehicle = timetable_data.nb_of_vehicle();
+            let after_last_vehicle_idx = VehicleIdx { idx: nb_of_vehicle };
             if self.current_vehicle_idx.idx < nb_of_vehicle {
                 let vehicle_idx = self.current_vehicle_idx;
                 self.current_vehicle_idx = VehicleIdx {
@@ -883,9 +885,7 @@ impl<'a, const BOARD_TIMES: bool> Iterator for TripsBetween<'a, BOARD_TIMES> {
                             .earliest_vehicle_to_board(&from_time_in_day, self.position_idx, |_| {
                                 true
                             })
-                            .unwrap_or_else(|| VehicleIdx {
-                                idx: timetable_data.nb_of_vehicle(),
-                            });
+                            .unwrap_or(after_last_vehicle_idx);
                     } else {
                         self.current_vehicle_idx = timetable_data
                             .earliest_vehicle_that_debark(
@@ -893,9 +893,7 @@ impl<'a, const BOARD_TIMES: bool> Iterator for TripsBetween<'a, BOARD_TIMES> {
                                 self.position_idx,
                                 |_| true,
                             )
-                            .unwrap_or_else(|| VehicleIdx {
-                                idx: timetable_data.nb_of_vehicle(),
-                            });
+                            .unwrap_or(after_last_vehicle_idx);
                     }
 
                     self.current_until_time_in_day = until_time_in_day;

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -248,7 +248,7 @@ impl UTCTimetables {
         )> = None;
 
         for (waiting_day, waiting_time_in_day) in decompositions {
-            let has_vehicle = self.timetables.earliest_filtered_vehicle_to_board(
+            let has_vehicle = self.timetables.earliest_vehicle_to_board(
                 &waiting_time_in_day,
                 mission,
                 position,
@@ -794,7 +794,7 @@ impl<'a, const BOARD_TIMES: bool> TripsBetween<'a, BOARD_TIMES> {
             // find first vehicle that depart after from_time_in_day
             let current_vehicle_idx = if BOARD_TIMES {
                 timetable_data
-                    .earliest_vehicle_to_board(&from_time_in_day, position_idx)
+                    .earliest_vehicle_to_board(&from_time_in_day, position_idx, |_| true)
                     .unwrap_or_else(|| timetable_data.nb_of_vehicle())
             } else {
                 timetable_data
@@ -911,7 +911,9 @@ impl<'a, const BOARD_TIMES: bool> Iterator for TripsBetween<'a, BOARD_TIMES> {
                     // find first vehicle that depart after from_time_in_day
                     if BOARD_TIMES {
                         self.current_vehicle_idx = timetable_data
-                            .earliest_vehicle_to_board(&from_time_in_day, self.position_idx)
+                            .earliest_vehicle_to_board(&from_time_in_day, self.position_idx, |_| {
+                                true
+                            })
                             .unwrap_or_else(|| timetable_data.nb_of_vehicle());
                     } else {
                         self.current_vehicle_idx = timetable_data

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -36,7 +36,7 @@
 
 use crate::{
     loads_data::{Load, LoadsData},
-    models::VehicleJourneyIdx,
+    models::{StopTimeIdx, VehicleJourneyIdx},
     time::{
         calendar::DecomposeUTCResult,
         days_patterns::{DaysInPatternIter, DaysPattern, DaysPatterns},
@@ -99,7 +99,7 @@ impl UTCTimetables {
             .clone()
     }
 
-    pub fn stoptime_idx(&self, position: &Position, _trip: &Trip) -> usize {
+    pub fn stoptime_idx(&self, position: &Position, _trip: &Trip) -> StopTimeIdx {
         self.timetables.stoptime_idx(position)
     }
 

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -202,27 +202,7 @@ impl UTCTimetables {
             })
     }
 
-    pub fn earliest_trip_to_board_at(
-        &self,
-        waiting_time: SecondsSinceDatasetUTCStart,
-        mission: &Mission,
-        position: &Position,
-        real_time_level: RealTimeLevel,
-        calendar: &Calendar,
-        days_patterns: &DaysPatterns,
-    ) -> Option<(Trip, SecondsSinceDatasetUTCStart, Load)> {
-        self.earliest_filtered_trip_to_board_at(
-            waiting_time,
-            mission,
-            position,
-            real_time_level,
-            |_| true,
-            calendar,
-            days_patterns,
-        )
-    }
-
-    pub fn earliest_filtered_trip_to_board_at<Filter>(
+    pub fn earliest_trip_to_board<Filter>(
         &self,
         waiting_time: SecondsSinceDatasetUTCStart,
         mission: &Mission,
@@ -292,27 +272,7 @@ impl UTCTimetables {
         )
     }
 
-    pub fn latest_trip_that_debark_at(
-        &self,
-        time: SecondsSinceDatasetUTCStart,
-        mission: &Mission,
-        position: &Position,
-        real_time_level: RealTimeLevel,
-        calendar: &Calendar,
-        days_patterns: &DaysPatterns,
-    ) -> Option<(Trip, SecondsSinceDatasetUTCStart, Load)> {
-        self.latest_filtered_trip_that_debark_at(
-            time,
-            mission,
-            position,
-            real_time_level,
-            |_| true,
-            calendar,
-            days_patterns,
-        )
-    }
-
-    pub fn latest_filtered_trip_that_debark_at<Filter>(
+    pub fn latest_trip_that_debark<Filter>(
         &self,
         time: SecondsSinceDatasetUTCStart,
         mission: &Mission,

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -238,6 +238,7 @@ impl UTCTimetables {
         let decompositions = calendar.decompositions_utc(waiting_time);
 
         // if there is not next position, we cannot board this mission at this posision
+        // TODO : revise this comment when stay_ins are implemented
         let next_position = self.timetables.next_position(position, mission)?;
 
         let mut best_vehicle_day_and_its_arrival_time_at_next_position: Option<(
@@ -324,6 +325,9 @@ impl UTCTimetables {
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool,
     {
+        // if there is not prev position, we cannot debark this mission at this posision
+        // TODO : revise this comment when stay_ins are implemented
+        let prev_position = self.timetables.previous_position(position, mission)?;
         let decompositions = calendar.decompositions_utc(time);
         let mut best_vehicle_day_and_its_departure_time_at_previous_position: Option<(
             Vehicle,
@@ -345,10 +349,13 @@ impl UTCTimetables {
                         && filter(&vehicle_data.vehicle_journey_idx)
                 },
             );
-            if let Some((vehicle, departure_time_in_day_at_previous_stop, load)) = has_vehicle {
+            if let Some(vehicle) = has_vehicle {
+                let departure_time_in_day_at_previous_stop =
+                    self.timetables.departure_time(&vehicle, &prev_position);
                 let departure_time_at_previous_stop =
                     calendar.compose_utc(&waiting_day, departure_time_in_day_at_previous_stop);
 
+                let load = self.timetables.load_before(&vehicle, &position);
                 if let Some((_, _, best_departure_time, best_load)) =
                     &best_vehicle_day_and_its_departure_time_at_previous_position
                 {

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -217,7 +217,7 @@ impl UTCTimetables {
     {
         let decompositions = calendar.decompositions_utc(waiting_time);
 
-        // if there is not next position, we cannot board this mission at this posision
+        // if there is not next position, we cannot board this mission at this position
         // TODO : revise this comment when stay_ins are implemented
         let next_position = self.timetables.next_position(position, mission)?;
 

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -320,24 +320,7 @@ impl data_interface::Data for TransitData {
         )
     }
 
-    fn earliest_trip_to_board_at(
-        &self,
-        waiting_time: SecondsSinceDatasetUTCStart,
-        mission: &Self::Mission,
-        position: &Self::Position,
-        real_time_level: RealTimeLevel,
-    ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
-        self.timetables.earliest_trip_to_board_at(
-            waiting_time,
-            mission,
-            position,
-            real_time_level,
-            &self.calendar,
-            &self.days_patterns,
-        )
-    }
-
-    fn earliest_filtered_trip_to_board_at<Filter>(
+    fn earliest_trip_to_board<Filter>(
         &self,
         waiting_time: SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
@@ -348,7 +331,7 @@ impl data_interface::Data for TransitData {
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool,
     {
-        self.timetables.earliest_filtered_trip_to_board_at(
+        self.timetables.earliest_trip_to_board(
             waiting_time,
             mission,
             position,
@@ -359,24 +342,7 @@ impl data_interface::Data for TransitData {
         )
     }
 
-    fn latest_trip_that_debark_at(
-        &self,
-        waiting_time: SecondsSinceDatasetUTCStart,
-        mission: &Self::Mission,
-        position: &Self::Position,
-        real_time_level: RealTimeLevel,
-    ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
-        self.timetables.latest_trip_that_debark_at(
-            waiting_time,
-            mission,
-            position,
-            real_time_level,
-            &self.calendar,
-            &self.days_patterns,
-        )
-    }
-
-    fn latest_filtered_trip_that_debark_at<Filter>(
+    fn latest_trip_that_debark<Filter>(
         &self,
         waiting_time: SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
@@ -387,7 +353,7 @@ impl data_interface::Data for TransitData {
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool,
     {
-        self.timetables.latest_filtered_trip_that_debark_at(
+        self.timetables.latest_trip_that_debark(
             waiting_time,
             mission,
             position,

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -377,8 +377,7 @@ impl data_interface::Data for TransitData {
     }
 
     fn stoptime_idx(&self, position: &Self::Position, trip: &Self::Trip) -> StopTimeIdx {
-        let idx = self.timetables.stoptime_idx(position, trip);
-        StopTimeIdx { idx }
+        self.timetables.stoptime_idx(position, trip)
     }
 
     fn day_of(&self, trip: &Self::Trip) -> chrono::NaiveDate {

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -127,15 +127,7 @@ pub trait Data: TransitTypes {
         real_time_level: RealTimeLevel,
     ) -> Option<Self::Trip>;
 
-    fn earliest_trip_to_board_at(
-        &self,
-        waiting_time: SecondsSinceDatasetUTCStart,
-        mission: &Self::Mission,
-        position: &Self::Position,
-        real_time_level: RealTimeLevel,
-    ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>;
-
-    fn earliest_filtered_trip_to_board_at<Filter>(
+    fn earliest_trip_to_board<Filter>(
         &self,
         waiting_time: SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
@@ -146,15 +138,7 @@ pub trait Data: TransitTypes {
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool;
 
-    fn latest_trip_that_debark_at(
-        &self,
-        waiting_time: SecondsSinceDatasetUTCStart,
-        mission: &Self::Mission,
-        position: &Self::Position,
-        real_time_level: RealTimeLevel,
-    ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)>;
-
-    fn latest_filtered_trip_that_debark_at<Filter>(
+    fn latest_trip_that_debark<Filter>(
         &self,
         waiting_time: SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,

--- a/src/transit_data_filtered.rs
+++ b/src/transit_data_filtered.rs
@@ -275,31 +275,7 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         self.transit_data.stay_in_next(trip, real_time_level)
     }
 
-    fn earliest_trip_to_board_at(
-        &self,
-        waiting_time: SecondsSinceDatasetUTCStart,
-        mission: &Self::Mission,
-        position: &Self::Position,
-        real_time_level: RealTimeLevel,
-    ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
-        let stop = self.stop_of(position, mission);
-
-        if self.is_stop_allowed(&stop) {
-            self.transit_data.earliest_filtered_trip_to_board_at(
-                waiting_time,
-                mission,
-                position,
-                real_time_level,
-                |vehicle_journey_idx: &VehicleJourneyIdx| {
-                    self.is_vehicle_journey_allowed(vehicle_journey_idx)
-                },
-            )
-        } else {
-            None
-        }
-    }
-
-    fn earliest_filtered_trip_to_board_at<Filter>(
+    fn earliest_trip_to_board<Filter>(
         &self,
         waiting_time: SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
@@ -312,7 +288,7 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
     {
         let stop = self.stop_of(position, mission);
         if self.is_stop_allowed(&stop) {
-            self.transit_data.earliest_filtered_trip_to_board_at(
+            self.transit_data.earliest_trip_to_board(
                 waiting_time,
                 mission,
                 position,
@@ -327,31 +303,7 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         }
     }
 
-    fn latest_trip_that_debark_at(
-        &self,
-        waiting_time: SecondsSinceDatasetUTCStart,
-        mission: &Self::Mission,
-        position: &Self::Position,
-        real_time_level: RealTimeLevel,
-    ) -> Option<(Self::Trip, SecondsSinceDatasetUTCStart, Load)> {
-        let stop = self.stop_of(position, mission);
-
-        if self.is_stop_allowed(&stop) {
-            self.transit_data.latest_filtered_trip_that_debark_at(
-                waiting_time,
-                mission,
-                position,
-                real_time_level,
-                |vehicle_journey_idx: &VehicleJourneyIdx| {
-                    self.is_vehicle_journey_allowed(vehicle_journey_idx)
-                },
-            )
-        } else {
-            None
-        }
-    }
-
-    fn latest_filtered_trip_that_debark_at<Filter>(
+    fn latest_trip_that_debark<Filter>(
         &self,
         waiting_time: SecondsSinceDatasetUTCStart,
         mission: &Self::Mission,
@@ -365,7 +317,7 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         let stop = self.stop_of(position, mission);
 
         if self.is_stop_allowed(&stop) {
-            self.transit_data.latest_filtered_trip_that_debark_at(
+            self.transit_data.latest_trip_that_debark(
                 waiting_time,
                 mission,
                 position,


### PR DESCRIPTION
- Remove the non-filtered versions, and pass a `|_| true` filter when no filtering is needed.
- Reword the comments
- Uniformize the return types in `timetable_data` (`latest_vehicle_that_debark` was returning an `Option<(usize, Time)>` while the other returned an `Option<usize>`)