### PR TITLE
Robustness by mode sequence

### DIFF
--- a/launch/src/config/comparator_type.rs
+++ b/launch/src/config/comparator_type.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
 pub enum ComparatorType {
     Loads,
     Basic,
+    Robustness,
 }
 impl std::str::FromStr for ComparatorType {
     type Err = ComparatorTypeConfigError;
@@ -48,6 +49,7 @@ impl std::str::FromStr for ComparatorType {
         let request_type = match s {
             "loads" => ComparatorType::Loads,
             "basic" => ComparatorType::Basic,
+            "robustness" => ComparatorType::Robustness,
             _ => {
                 return Err(ComparatorTypeConfigError {
                     comparator_type_name: s.to_string(),
@@ -69,6 +71,7 @@ impl std::fmt::Display for ComparatorType {
         match self {
             ComparatorType::Loads => write!(f, "loads"),
             ComparatorType::Basic => write!(f, "basic"),
+            ComparatorType::Robustness => write!(f, "robustness"),
         }
     }
 }

--- a/launch/src/datetime.rs
+++ b/launch/src/datetime.rs
@@ -36,7 +36,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum DateTimeRepresent {
     Departure,

--- a/launch/src/solver.rs
+++ b/launch/src/solver.rs
@@ -94,7 +94,7 @@ impl Solver {
         Self: Sized,
     {
         use crate::datetime::DateTimeRepresent::{Arrival, Departure};
-        use config::ComparatorType::{Basic, Loads};
+        use config::ComparatorType::{Basic, Loads, Robustness};
 
         if let Some(filters) = has_filters {
             self.fill_allowed_stops_and_vehicles(model, &filters);
@@ -134,6 +134,23 @@ impl Solver {
                     )?;
                     solve_journeys_request_inner(&mut self.engine, &request, &data)
                 }
+
+                (Arrival, Robustness) => {
+                    let request = request::arrive_before::robustness_comparator::Request::new(
+                        model,
+                        &data,
+                        request_input,
+                    )?;
+                    solve_journeys_request_inner(&mut self.engine, &request, &data)
+                }
+                (Departure, Robustness) => {
+                    let request = request::depart_after::robustness_comparator::Request::new(
+                        model,
+                        &data,
+                        request_input,
+                    )?;
+                    solve_journeys_request_inner(&mut self.engine, &request, &data)
+                }
             };
             Ok(responses)
         } else {
@@ -164,6 +181,22 @@ impl Solver {
                 }
                 (Departure, Basic) => {
                     let request = request::depart_after::basic_comparator::Request::new(
+                        model,
+                        data,
+                        request_input,
+                    )?;
+                    solve_journeys_request_inner(&mut self.engine, &request, data)
+                }
+                (Arrival, Robustness) => {
+                    let request = request::arrive_before::robustness_comparator::Request::new(
+                        model,
+                        data,
+                        request_input,
+                    )?;
+                    solve_journeys_request_inner(&mut self.engine, &request, data)
+                }
+                (Departure, Robustness) => {
+                    let request = request::depart_after::robustness_comparator::Request::new(
                         model,
                         data,
                         request_input,

--- a/launch/src/solver.rs
+++ b/launch/src/solver.rs
@@ -88,8 +88,8 @@ impl Solver {
         model: &ModelRefs<'_>,
         request_input: &RequestInput,
         has_filters: Option<Filters>,
-        comparator_type: &config::ComparatorType,
-        datetime_represent: &DateTimeRepresent,
+        comparator_type: config::ComparatorType,
+        datetime_represent: DateTimeRepresent,
     ) -> Result<Vec<response::Response>, BadRequest>
     where
         Self: Sized,
@@ -153,8 +153,8 @@ fn select_journeys_implem_and_solve<Data>(
     data: &Data,
     model: &ModelRefs<'_>,
     request_input: &RequestInput,
-    comparator_type: &config::ComparatorType,
-    datetime_represent: &DateTimeRepresent,
+    comparator_type: config::ComparatorType,
+    datetime_represent: DateTimeRepresent,
 ) -> Result<Vec<response::Response>, BadRequest>
 where
     Data: DataWithIters<
@@ -172,22 +172,22 @@ where
         (Arrival, Loads) => {
             let request =
                 request::arrive_before::loads_comparator::Request::new(model, data, request_input)?;
-            solve_journeys_request_inner(engine, &request, &data)
+            solve_journeys_request_inner(engine, &request, data)
         }
         (Departure, Loads) => {
             let request =
                 request::depart_after::loads_comparator::Request::new(model, data, request_input)?;
-            solve_journeys_request_inner(engine, &request, &data)
+            solve_journeys_request_inner(engine, &request, data)
         }
         (Arrival, Basic) => {
             let request =
                 request::arrive_before::basic_comparator::Request::new(model, data, request_input)?;
-            solve_journeys_request_inner(engine, &request, &data)
+            solve_journeys_request_inner(engine, &request, data)
         }
         (Departure, Basic) => {
             let request =
                 request::depart_after::basic_comparator::Request::new(model, data, request_input)?;
-            solve_journeys_request_inner(engine, &request, &data)
+            solve_journeys_request_inner(engine, &request, data)
         }
 
         (Arrival, Robustness) => {
@@ -196,7 +196,7 @@ where
                 data,
                 request_input,
             )?;
-            solve_journeys_request_inner(engine, &request, &data)
+            solve_journeys_request_inner(engine, &request, data)
         }
         (Departure, Robustness) => {
             let request = request::depart_after::robustness_comparator::Request::new(
@@ -204,7 +204,7 @@ where
                 data,
                 request_input,
             )?;
-            solve_journeys_request_inner(engine, &request, &data)
+            solve_journeys_request_inner(engine, &request, data)
         }
     };
 

--- a/launch/tests/loads_test.rs
+++ b/launch/tests/loads_test.rs
@@ -85,11 +85,10 @@ fn test_loads_matin() -> Result<(), Error> {
 
     let base_model = create_model();
 
-    let config = Config::new("2021-01-01T08:00:00", "massy", "paris");
-    let config = Config {
-        comparator_type: ComparatorType::Loads,
-        ..config
-    };
+    let mut config = Config::new("2021-01-01T08:00:00", "massy", "paris");
+    config.comparator_type = ComparatorType::Loads;
+    config.request_params.too_late_threshold = PositiveDuration::from_hms(24, 0, 0);
+
     let real_time_model = RealTimeModel::new();
     let model_refs = ModelRefs::new(&base_model, &real_time_model);
 

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -46,6 +46,7 @@ use loki::{
         self, base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs, StopTime,
         VehicleJourneyIdx,
     },
+    robustness::Regularity,
     timetables::InsertionError,
     DataTrait, RealTimeLevel,
 };
@@ -495,6 +496,7 @@ fn modify_vj() -> Result<(), Error> {
             dates,
             UTC,
             &vj_idx,
+            Regularity::Rare,
         );
         assert!(result.is_ok());
     }
@@ -632,6 +634,7 @@ fn modify_vj_with_local_zone() -> Result<(), Error> {
             dates,
             UTC,
             &vj_idx,
+            Regularity::Rare,
         );
         assert!(result.is_ok());
     }
@@ -940,6 +943,7 @@ fn insert_invalid_vj() -> Result<(), Error> {
             dates,
             UTC,
             vj_idx,
+            Regularity::Rare,
         );
         match insert_result {
             Err(InsertionError::InvalidDate(_, _)) => {
@@ -976,6 +980,7 @@ fn insert_invalid_vj() -> Result<(), Error> {
             dates,
             UTC,
             vj_idx,
+            Regularity::Rare,
         );
         match insert_result {
             Err(InsertionError::NoValidDates(_)) => {
@@ -1018,6 +1023,7 @@ fn insert_invalid_vj() -> Result<(), Error> {
             dates,
             UTC,
             vj_idx,
+            Regularity::Rare,
         );
         match insert_result {
             Err(InsertionError::Times(_, _, _, _)) => {
@@ -1047,6 +1053,7 @@ fn insert_invalid_vj() -> Result<(), Error> {
             dates,
             UTC,
             vj_idx,
+            Regularity::Rare,
         );
         match insert_result {
             Err(InsertionError::RealTimeVehicleJourneyAlreadyExistsOnDate(_, _)) => {
@@ -1089,6 +1096,7 @@ fn insert_invalid_vj() -> Result<(), Error> {
             dates,
             UTC,
             vj_idx.clone(),
+            Regularity::Rare,
         );
 
         assert!(insert_result.is_ok());
@@ -1107,6 +1115,7 @@ fn insert_invalid_vj() -> Result<(), Error> {
             dates,
             UTC,
             vj_idx,
+            Regularity::Rare,
         );
 
         match insert_result {

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -99,8 +99,8 @@ fn remove_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -131,8 +131,8 @@ fn remove_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 0);
@@ -146,8 +146,8 @@ fn remove_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -215,8 +215,8 @@ fn remove_successive_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -242,8 +242,8 @@ fn remove_successive_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -269,8 +269,8 @@ fn remove_successive_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -296,8 +296,8 @@ fn remove_successive_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 0);
@@ -353,8 +353,8 @@ fn remove_middle_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -379,8 +379,8 @@ fn remove_middle_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -405,8 +405,8 @@ fn remove_middle_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -457,8 +457,8 @@ fn modify_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -512,8 +512,8 @@ fn modify_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         // the request is to depart at 9:50, but the vehicle depart at 9:45 at the real time level
@@ -531,8 +531,8 @@ fn modify_vj() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         // the request is to depart at 9:50,
@@ -589,8 +589,8 @@ fn modify_vj_with_local_zone() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -650,8 +650,8 @@ fn modify_vj_with_local_zone() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         // All base vehicle journeys are deactivated
@@ -679,8 +679,8 @@ fn modify_vj_with_local_zone() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -708,8 +708,8 @@ fn modify_vj_with_local_zone() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         // we should not get any response, since A and C are in the same local zone
@@ -727,8 +727,8 @@ fn modify_vj_with_local_zone() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         // we should not get a response, since there is no local zone on
@@ -789,8 +789,8 @@ fn remove_vj_with_local_zone() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -806,8 +806,8 @@ fn remove_vj_with_local_zone() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         assert_eq!(responses.len(), 1);
@@ -842,8 +842,8 @@ fn remove_vj_with_local_zone() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         // the first vehicle_journey is totally removed for RealTime, the only solution is to take
@@ -873,8 +873,8 @@ fn remove_vj_with_local_zone() -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            &config.datetime_represent,
+            config.comparator_type,
+            config.datetime_represent,
         )?;
 
         // the request is to depart at 9:50,

--- a/launch/tests/utils/mod.rs
+++ b/launch/tests/utils/mod.rs
@@ -170,8 +170,8 @@ pub fn build_and_solve(
         model,
         &request_input,
         filters,
-        &config.comparator_type,
-        &config.datetime_represent,
+        config.comparator_type,
+        config.datetime_represent,
     )?;
     for response in responses.iter() {
         debug!("{}", response.print(model)?);

--- a/random/src/main.rs
+++ b/random/src/main.rs
@@ -144,8 +144,8 @@ pub fn launch(config: &Config) -> Result<(), Error> {
             &model_refs,
             &request_input,
             None,
-            &config.comparator_type,
-            datetime_represent,
+            config.comparator_type,
+            *datetime_represent,
         );
         let solve_duration = before_solve.elapsed().unwrap().as_millis();
         let solve_duration_u64: u64 = TryFrom::try_from(solve_duration).unwrap();

--- a/random/src/main.rs
+++ b/random/src/main.rs
@@ -116,7 +116,7 @@ pub fn launch(config: &Config) -> Result<(), Error> {
         }
     };
 
-    let datetime_represent = &config.datetime_represent;
+    let datetime_represent = config.datetime_represent;
 
     let start_all = SystemTime::now();
 
@@ -145,7 +145,7 @@ pub fn launch(config: &Config) -> Result<(), Error> {
             &request_input,
             None,
             config.comparator_type,
-            *datetime_represent,
+            datetime_represent,
         );
         let solve_duration = before_solve.elapsed().unwrap().as_millis();
         let solve_duration_u64: u64 = TryFrom::try_from(solve_duration).unwrap();

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -544,14 +544,12 @@ fn solve(
 
     let leg_arrival_penalty = journey_request
         .arrival_transfer_penalty
-        .map(|seconds_i32| PositiveDuration::try_from(seconds_i32))
-        .flatten()
+        .and_then(|seconds_i32| PositiveDuration::try_from(seconds_i32).ok())
         .unwrap_or(default_request_params.leg_arrival_penalty);
 
     let leg_walking_penalty = journey_request
         .walking_transfer_penalty
-        .map(|seconds_i32| PositiveDuration::try_from(seconds_i32))
-        .flatten()
+        .and_then(|seconds_i32| PositiveDuration::try_from(seconds_i32).ok())
         .unwrap_or(default_request_params.leg_walking_penalty);
 
     let request_input = RequestInput {

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -575,8 +575,8 @@ fn solve(
         model,
         &request_input,
         data_filters,
-        &comparator_type,
-        &datetime_represent,
+        comparator_type,
+        datetime_represent,
     )?;
     for response in &responses {
         debug!("{}", response.print(model)?);

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -41,7 +41,7 @@ use crate::{
 };
 use anyhow::{anyhow, format_err, Context, Error};
 use launch::{
-    config,
+    config::{self, ComparatorType},
     datetime::DateTimeRepresent,
     loki::{
         self,
@@ -214,12 +214,6 @@ impl ComputeWorker {
                 Ok(make_error_response(&err))
             }
             Ok(journey_request) => {
-                let real_time_level = match journey_request.realtime_level() {
-                    navitia_proto::RtLevel::BaseSchedule => RealTimeLevel::Base,
-                    navitia_proto::RtLevel::Realtime | navitia_proto::RtLevel::AdaptedSchedule => {
-                        RealTimeLevel::RealTime
-                    }
-                };
                 let rw_lock_read_guard = self.data_and_models.read().map_err(|err| {
                     format_err!(
                         "Compute worker {} failed to acquire read lock on data_and_models. {}",
@@ -237,8 +231,6 @@ impl ComputeWorker {
                     &model_refs,
                     &mut self.solver,
                     &self.default_request_params,
-                    &config::ComparatorType::Basic,
-                    real_time_level,
                 );
 
                 let response = make_proto_response(solve_result, &model_refs);
@@ -401,8 +393,6 @@ fn solve(
     model: &ModelRefs<'_>,
     solver: &mut Solver,
     default_request_params: &config::RequestParams,
-    comparator_type: &config::ComparatorType,
-    real_time_level: RealTimeLevel,
 ) -> Result<(RequestInput, Vec<loki::response::Response>), Error> {
     // println!("{:#?}", journey_request);
     let departures_stop_point_and_fallback_duration = journey_request
@@ -532,6 +522,26 @@ fn solve(
         must_be_bike_accessible,
     );
 
+    let real_time_level = if journey_request.realtime_level.is_some() {
+        match journey_request.realtime_level() {
+            navitia_proto::RtLevel::BaseSchedule => RealTimeLevel::Base,
+            navitia_proto::RtLevel::Realtime | navitia_proto::RtLevel::AdaptedSchedule => {
+                RealTimeLevel::RealTime
+            }
+        }
+    } else {
+        RealTimeLevel::RealTime
+    };
+
+    let comparator_type = if journey_request.criteria.is_some() {
+        match journey_request.criteria() {
+            navitia_proto::Criteria::Classic => ComparatorType::Basic,
+            navitia_proto::Criteria::Robustness => ComparatorType::Robustness,
+        }
+    } else {
+        ComparatorType::Basic
+    };
+
     let request_input = RequestInput {
         datetime: departure_datetime,
         departures_stop_point_and_fallback_duration,
@@ -555,7 +565,7 @@ fn solve(
         model,
         &request_input,
         data_filters,
-        comparator_type,
+        &comparator_type,
         &datetime_represent,
     )?;
     for response in &responses {

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -542,12 +542,24 @@ fn solve(
         ComparatorType::Basic
     };
 
+    let leg_arrival_penalty = journey_request
+        .arrival_transfer_penalty
+        .map(|seconds_i32| PositiveDuration::try_from(seconds_i32))
+        .flatten()
+        .unwrap_or(default_request_params.leg_arrival_penalty);
+
+    let leg_walking_penalty = journey_request
+        .walking_transfer_penalty
+        .map(|seconds_i32| PositiveDuration::try_from(seconds_i32))
+        .flatten()
+        .unwrap_or(default_request_params.leg_walking_penalty);
+
     let request_input = RequestInput {
         datetime: departure_datetime,
         departures_stop_point_and_fallback_duration,
         arrivals_stop_point_and_fallback_duration,
-        leg_arrival_penalty: default_request_params.leg_arrival_penalty,
-        leg_walking_penalty: default_request_params.leg_walking_penalty,
+        leg_arrival_penalty,
+        leg_walking_penalty,
         max_nb_of_legs,
         max_journey_duration,
         too_late_threshold: default_request_params.too_late_threshold,

--- a/server/src/data_worker.rs
+++ b/server/src/data_worker.rs
@@ -553,7 +553,6 @@ impl DataWorker {
                     Ok(proto_message) => {
                         let action = proto_message.action();
                         if let navitia_proto::Action::Reload = action {
-                            debug!("Received a Reload order.");
                             let reload_result = self.load_data().await?;
                             match reload_result {
                                 DataReloadStatus::Ok => {

--- a/server/src/data_worker.rs
+++ b/server/src/data_worker.rs
@@ -76,7 +76,7 @@ use launch::{
             },
             RealTimeModel,
         },
-        tracing::{debug, error, info, log::trace, warn},
+        tracing::{error, info, log::trace, warn},
         DataTrait, NaiveDateTime,
     },
     timer::duration_since,
@@ -284,6 +284,8 @@ impl DataWorker {
     }
 
     async fn load_data(&mut self) -> Result<DataReloadStatus, Error> {
+        let start_load_data_time = SystemTime::now();
+
         let config = &self.config;
 
         let new_base_model = match &mut self.data_source {
@@ -339,6 +341,11 @@ impl DataWorker {
         };
 
         let load_result = self.update_data_and_models(updater).await;
+
+        info!(
+            "Load data completed in {} ms",
+            duration_since(start_load_data_time)
+        );
 
         match load_result {
             Ok(base_data_info) => {
@@ -559,7 +566,7 @@ impl DataWorker {
                                         error!("Error during reload of Chaos database : {:?}", err);
                                     }
                                     self.reload_kirin(channel).await?;
-                                    debug!("Reload completed successfully.");
+                                    info!("Reload completed successfully.");
                                 }
                                 DataReloadStatus::Skipped => {
                                     info!("Reload skipped");

--- a/server/tests/main_test.rs
+++ b/server/tests/main_test.rs
@@ -480,7 +480,7 @@ fn make_journeys_request(
         ..Default::default()
     };
 
-    let journeys = navitia_proto::JourneysRequest {
+    let mut journeys = navitia_proto::JourneysRequest {
         origin: vec![origin],
         destination: vec![destination],
         datetimes: vec![from_datetime.timestamp() as u64],
@@ -488,6 +488,7 @@ fn make_journeys_request(
         max_duration: 24 * 60 * 60, // 1 day
         ..Default::default()
     };
+    journeys.set_realtime_level(navitia_proto::RtLevel::BaseSchedule);
 
     let mut request = navitia_proto::Request {
         journeys: Some(journeys),

--- a/src/engine/multicriteria_raptor.rs
+++ b/src/engine/multicriteria_raptor.rs
@@ -533,6 +533,9 @@ where
             let new_debark_front = &self.new_debark_fronts[stop_id];
             for (debark, criteria) in new_debark_front.iter() {
                 let arrive_criteria = pt.arrive(&arrival, criteria);
+                if self.can_be_discarded(&arrive_criteria, pt) {
+                    continue;
+                }
                 if self.arrive_front.dominates(&arrive_criteria, pt) {
                     continue;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,5 +75,7 @@ pub mod response;
 
 pub type Response = response::Response;
 
+pub mod robustness;
+
 #[macro_use]
 extern crate lazy_static;

--- a/src/models/real_time_disruption/apply_disruption.rs
+++ b/src/models/real_time_disruption/apply_disruption.rs
@@ -39,6 +39,7 @@ use tracing::{debug, trace};
 use crate::{
     chrono::NaiveDate,
     models::{self, real_time_model::TripVersion, RealTimeModel, VehicleJourneyIdx},
+    robustness::Regularity,
     transit_data::{
         data_interface::Data as DataTrait, handle_insertion_error, handle_modify_error,
         handle_removal_error,
@@ -99,22 +100,24 @@ pub(super) fn add_trip(
     date: NaiveDate,
     stop_times: Vec<models::StopTime>,
 ) {
-    {
-        let model_ref = ModelRefs {
-            base: base_model,
-            real_time: real_time_model,
-        };
-        debug!(
-            "Adding vehicle journey {} on {}",
-            model_ref.vehicle_journey_name(&vehicle_journey_idx),
-            date
-        );
-    }
+    let model_ref = ModelRefs {
+        base: base_model,
+        real_time: real_time_model,
+    };
+    debug!(
+        "Adding vehicle journey {} on {}",
+        model_ref.vehicle_journey_name(&vehicle_journey_idx),
+        date
+    );
+    let physical_mode = model_ref.physical_mode_name(&vehicle_journey_idx);
+    let regularity = Regularity::new(physical_mode);
+
     let dates = std::iter::once(date);
     let stops = stop_times.iter().map(|stop_time| stop_time.stop.clone());
     let flows = stop_times.iter().map(|stop_time| stop_time.flow_direction);
     let board_times = stop_times.iter().map(|stop_time| stop_time.board_time);
     let debark_times = stop_times.iter().map(|stop_time| stop_time.debark_time);
+
     let insert_result = data.insert_real_time_vehicle(
         stops,
         flows,
@@ -124,6 +127,7 @@ pub(super) fn add_trip(
         dates,
         chrono_tz::UTC,
         vehicle_journey_idx,
+        regularity,
     );
     let model_ref = ModelRefs {
         base: base_model,
@@ -147,17 +151,17 @@ pub fn modify_trip(
     date: &NaiveDate,
     stop_times: Vec<models::StopTime>,
 ) {
-    {
-        let model_ref = ModelRefs {
-            base: base_model,
-            real_time: real_time_model,
-        };
-        debug!(
-            "Modifying vehicle journey {} on {}",
-            model_ref.vehicle_journey_name(vehicle_journey_idx),
-            date
-        );
-    }
+    let model_ref = ModelRefs {
+        base: base_model,
+        real_time: real_time_model,
+    };
+    debug!(
+        "Modifying vehicle journey {} on {}",
+        model_ref.vehicle_journey_name(vehicle_journey_idx),
+        date
+    );
+    let physical_mode = model_ref.physical_mode_name(&vehicle_journey_idx);
+    let regularity = Regularity::new(physical_mode);
     let dates = std::iter::once(*date);
     let stops = stop_times.iter().map(|stop_time| stop_time.stop.clone());
     let flows = stop_times.iter().map(|stop_time| stop_time.flow_direction);
@@ -173,6 +177,7 @@ pub fn modify_trip(
         dates,
         chrono_tz::UTC,
         vehicle_journey_idx,
+        regularity,
     );
     if let Err(err) = modify_result {
         let model_ref = ModelRefs {

--- a/src/models/real_time_disruption/apply_disruption.rs
+++ b/src/models/real_time_disruption/apply_disruption.rs
@@ -160,7 +160,7 @@ pub fn modify_trip(
         model_ref.vehicle_journey_name(vehicle_journey_idx),
         date
     );
-    let physical_mode = model_ref.physical_mode_name(&vehicle_journey_idx);
+    let physical_mode = model_ref.physical_mode_name(vehicle_journey_idx);
     let regularity = Regularity::new(physical_mode);
     let dates = std::iter::once(*date);
     let stops = stop_times.iter().map(|stop_time| stop_time.stop.clone());

--- a/src/request/arrive_before.rs
+++ b/src/request/arrive_before.rs
@@ -185,6 +185,7 @@ where
             connections,
             *arrival_fallback_duration,
             pt_journey.criteria_at_arrival.loads_count.clone(),
+            pt_journey.criteria_at_arrival.max_regularity,
             self.transit_data,
             self.real_time_level,
         )

--- a/src/request/arrive_before.rs
+++ b/src/request/arrive_before.rs
@@ -41,6 +41,7 @@ pub mod robustness_comparator;
 use crate::{
     loads_data::LoadsCount,
     models::ModelRefs,
+    robustness::Uncertainty,
     time::{PositiveDuration, SecondsSinceDatasetUTCStart},
     transit_data::data_interface::DataIters,
     RealTimeLevel,
@@ -185,7 +186,7 @@ where
             connections,
             *arrival_fallback_duration,
             pt_journey.criteria_at_arrival.loads_count.clone(),
-            pt_journey.criteria_at_arrival.max_regularity,
+            pt_journey.criteria_at_arrival.uncertainty,
             self.transit_data,
             self.real_time_level,
         )
@@ -259,7 +260,7 @@ where
             fallback_duration: waiting_criteria.fallback_duration,
             transfers_duration: waiting_criteria.transfers_duration,
             loads_count: waiting_criteria.loads_count.add(load),
-            max_regularity: std::cmp::max(regularity, waiting_criteria.max_regularity),
+            uncertainty: waiting_criteria.uncertainty.extend(regularity),
         };
         Some(new_criteria)
     }
@@ -280,7 +281,7 @@ where
             fallback_duration: criteria.fallback_duration,
             transfers_duration: criteria.transfers_duration,
             loads_count: criteria.loads_count.clone(),
-            max_regularity: std::cmp::max(regularity, criteria.max_regularity),
+            uncertainty: criteria.uncertainty.extend(regularity),
         };
         Some((previous_trip, new_criteria))
     }
@@ -308,7 +309,7 @@ where
                     fallback_duration: waiting_criteria.fallback_duration,
                     transfers_duration: waiting_criteria.transfers_duration,
                     loads_count: waiting_criteria.loads_count.add(load),
-                    max_regularity: std::cmp::max(regularity, waiting_criteria.max_regularity),
+                    uncertainty: waiting_criteria.uncertainty.extend(regularity),
                 };
                 (trip, new_criteria)
             })
@@ -332,7 +333,7 @@ where
                 fallback_duration: onboard_criteria.fallback_duration,
                 transfers_duration: onboard_criteria.transfers_duration,
                 loads_count: onboard_criteria.loads_count.clone(),
-                max_regularity: onboard_criteria.max_regularity,
+                uncertainty: onboard_criteria.uncertainty,
             })
     }
 
@@ -352,7 +353,7 @@ where
             fallback_duration: criteria.fallback_duration,
             transfers_duration: criteria.transfers_duration,
             loads_count: criteria.loads_count.add(load),
-            max_regularity: criteria.max_regularity,
+            uncertainty: criteria.uncertainty,
         }
     }
 
@@ -365,7 +366,7 @@ where
             fallback_duration: *fallback_duration,
             transfers_duration: PositiveDuration::zero(),
             loads_count: LoadsCount::zero(),
-            max_regularity: crate::robustness::Regularity::Rare,
+            uncertainty: Uncertainty::zero(),
         };
         (stop.clone(), criteria)
     }
@@ -384,7 +385,7 @@ where
             fallback_duration: criteria.fallback_duration + *arrival_duration,
             transfers_duration: criteria.transfers_duration,
             loads_count: criteria.loads_count.clone(),
-            max_regularity: criteria.max_regularity,
+            uncertainty: criteria.uncertainty,
         }
     }
 
@@ -556,7 +557,7 @@ where
                 fallback_duration: self.criteria.fallback_duration,
                 transfers_duration: self.criteria.transfers_duration + durations.walking_duration,
                 loads_count: self.criteria.loads_count.clone(),
-                max_regularity: self.criteria.max_regularity,
+                uncertainty: self.criteria.uncertainty,
             };
             (stop.clone(), new_criteria, transfer.clone())
         })

--- a/src/request/arrive_before/robustness_comparator.rs
+++ b/src/request/arrive_before/robustness_comparator.rs
@@ -70,18 +70,15 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
         let lower_nb_of_legs = u32::from(lower.nb_of_legs);
         let upper_nb_of_legs = u32::from(upper.nb_of_legs);
 
-        let lower_uncertainty_level = u32::from(lower.uncertainty.level());
-        let upper_uncertainty_level = u32::from(upper.uncertainty.level());
-
         lower.time - arrival_penalty * lower_nb_of_legs
             >= upper.time - arrival_penalty * upper_nb_of_legs
-//            && lower.uncertainty <= upper.uncertainty
+            && lower.uncertainty <= upper.uncertainty
             && lower.fallback_duration
                 + lower.transfers_duration
-                + walking_penalty * lower_uncertainty_level
+                + walking_penalty * lower_nb_of_legs
                 <= upper.fallback_duration
                     + upper.transfers_duration
-                    + walking_penalty * upper_uncertainty_level
+                    + walking_penalty * upper_nb_of_legs
     }
 
     fn can_be_discarded(

--- a/src/request/arrive_before/robustness_comparator.rs
+++ b/src/request/arrive_before/robustness_comparator.rs
@@ -70,15 +70,18 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
         let lower_nb_of_legs = u32::from(lower.nb_of_legs);
         let upper_nb_of_legs = u32::from(upper.nb_of_legs);
 
+        let lower_uncertainty_level = u32::from(lower.uncertainty.level());
+        let upper_uncertainty_level = u32::from(upper.uncertainty.level());
+
         lower.time - arrival_penalty * lower_nb_of_legs
             >= upper.time - arrival_penalty * upper_nb_of_legs
-            && lower.uncertainty <= upper.uncertainty
+//            && lower.uncertainty <= upper.uncertainty
             && lower.fallback_duration
                 + lower.transfers_duration
-                + walking_penalty * lower_nb_of_legs
+                + walking_penalty * lower_uncertainty_level
                 <= upper.fallback_duration
                     + upper.transfers_duration
-                    + walking_penalty * upper_nb_of_legs
+                    + walking_penalty * upper_uncertainty_level
     }
 
     fn can_be_discarded(

--- a/src/request/arrive_before/robustness_comparator.rs
+++ b/src/request/arrive_before/robustness_comparator.rs
@@ -72,7 +72,7 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
 
         lower.time - arrival_penalty * lower_nb_of_legs
             >= upper.time - arrival_penalty * upper_nb_of_legs
-            && lower.uncertainty.is_lower(&upper.uncertainty)
+            && lower.uncertainty <= upper.uncertainty
             && lower.fallback_duration
                 + lower.transfers_duration
                 + walking_penalty * lower_nb_of_legs

--- a/src/request/arrive_before/robustness_comparator.rs
+++ b/src/request/arrive_before/robustness_comparator.rs
@@ -72,7 +72,7 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
 
         lower.time - arrival_penalty * lower_nb_of_legs
             >= upper.time - arrival_penalty * upper_nb_of_legs
-            && lower.max_regularity >= upper.max_regularity
+            && lower.uncertainty.is_lower(&upper.uncertainty)
             && lower.fallback_duration
                 + lower.transfers_duration
                 + walking_penalty * lower_nb_of_legs

--- a/src/request/arrive_before/robustness_comparator.rs
+++ b/src/request/arrive_before/robustness_comparator.rs
@@ -1,0 +1,298 @@
+// Copyright  (C) 2020, Hove and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+// the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+// powered by Hove (www.kisio.com).
+// Help us simplify mobility and open public transport:
+// a non ending quest to the responsive locomotion way of traveling!
+//
+// This contribution is a part of the research and development work of the
+// IVA Project which aims to enhance traveler information and is carried out
+// under the leadership of the Technological Research Institute SystemX,
+// with the partnership and support of the transport organization authority
+// Ile-De-France Mobilités (IDFM), SNCF, and public funds
+// under the scope of the French Program "Investissements d’Avenir".
+//
+// LICENCE: This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+use crate::{
+    engine::engine_interface::{
+        BadRequest, Request as RequestTrait, RequestDebug, RequestIO, RequestInput, RequestIters,
+        RequestTypes, RequestWithIters,
+    },
+    models::ModelRefs,
+    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes},
+};
+
+use super::{Arrival, Arrivals, Criteria, Departure, Departures, GenericArriveBeforeRequest};
+pub struct Request<'data, 'model, Data: DataTrait> {
+    generic: GenericArriveBeforeRequest<'data, 'model, Data>,
+}
+
+impl<'data, 'model, Data: DataTrait> TransitTypes for Request<'data, 'model, Data> {
+    type Stop = Data::Stop;
+    type Mission = Data::Mission;
+    type Position = Data::Position;
+    type Trip = Data::Trip;
+    type Transfer = Data::Transfer;
+}
+
+impl<'data, 'model, Data: DataTrait> RequestTypes for Request<'data, 'model, Data> {
+    type Departure = Departure;
+    type Arrival = Arrival;
+    type Criteria = Criteria;
+}
+
+impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Data> {
+    fn is_lower(&self, lower: &Self::Criteria, upper: &Self::Criteria) -> bool {
+        let arrival_penalty = self.generic.leg_arrival_penalty();
+        let walking_penalty = self.generic.leg_walking_penalty();
+
+        let lower_nb_of_legs = u32::from(lower.nb_of_legs);
+        let upper_nb_of_legs = u32::from(upper.nb_of_legs);
+
+        lower.time - arrival_penalty * lower_nb_of_legs
+            >= upper.time - arrival_penalty * upper_nb_of_legs
+            && lower.max_regularity >= upper.max_regularity
+            && lower.fallback_duration
+                + lower.transfers_duration
+                + walking_penalty * lower_nb_of_legs
+                <= upper.fallback_duration
+                    + upper.transfers_duration
+                    + walking_penalty * upper_nb_of_legs
+    }
+
+    fn can_be_discarded(
+        &self,
+        partial_journey_criteria: &Self::Criteria,
+        complete_journey_criteria: &Self::Criteria,
+    ) -> bool {
+        self.generic
+            .can_be_discarded(partial_journey_criteria, complete_journey_criteria)
+    }
+
+    fn is_valid(&self, criteria: &Self::Criteria) -> bool {
+        self.generic.is_valid(criteria)
+    }
+
+    fn board_and_ride(
+        &self,
+        position: &Self::Position,
+        trip: &Self::Trip,
+        waiting_criteria: &Self::Criteria,
+    ) -> Option<Self::Criteria> {
+        self.generic
+            .board_and_ride(position, trip, waiting_criteria)
+    }
+
+    fn best_trip_to_board(
+        &self,
+        position: &Self::Position,
+        mission: &Self::Mission,
+        waiting_criteria: &Self::Criteria,
+    ) -> Option<(Self::Trip, Self::Criteria)> {
+        self.generic
+            .best_trip_to_board(position, mission, waiting_criteria)
+    }
+
+    fn debark(
+        &self,
+        trip: &Self::Trip,
+        position: &Self::Position,
+        onboard_criteria: &Self::Criteria,
+    ) -> Option<Self::Criteria> {
+        self.generic.debark(trip, position, onboard_criteria)
+    }
+
+    fn ride(
+        &self,
+        trip: &Self::Trip,
+        position: &Self::Position,
+        criteria: &Self::Criteria,
+    ) -> Self::Criteria {
+        self.generic.ride(trip, position, criteria)
+    }
+
+    fn depart(&self, departure: &Self::Departure) -> (Self::Stop, Self::Criteria) {
+        self.generic.depart(departure)
+    }
+
+    fn arrive(&self, arrival: &Self::Arrival, criteria: &Self::Criteria) -> Self::Criteria {
+        self.generic.arrive(arrival, criteria)
+    }
+
+    fn arrival_stop(&self, arrival: &Self::Arrival) -> Self::Stop {
+        self.generic.arrival_stop(arrival)
+    }
+
+    fn is_upstream(
+        &self,
+        upstream: &Self::Position,
+        downstream: &Self::Position,
+        mission: &Self::Mission,
+    ) -> bool {
+        self.generic.is_upstream(upstream, downstream, mission)
+    }
+
+    fn next_on_mission(
+        &self,
+        stop: &Self::Position,
+        mission: &Self::Mission,
+    ) -> Option<Self::Position> {
+        self.generic.next_on_mission(stop, mission)
+    }
+
+    fn mission_of(&self, trip: &Self::Trip) -> Self::Mission {
+        self.generic.mission_of(trip)
+    }
+
+    fn stop_of(&self, position: &Self::Position, mission: &Self::Mission) -> Self::Stop {
+        self.generic.stop_of(position, mission)
+    }
+
+    fn nb_of_stops(&self) -> usize {
+        self.generic.nb_of_stops()
+    }
+
+    fn stop_id(&self, stop: &Self::Stop) -> usize {
+        self.generic.stop_id(stop)
+    }
+
+    fn nb_of_missions(&self) -> usize {
+        self.generic.nb_of_missions()
+    }
+
+    fn mission_id(&self, mission: &Self::Mission) -> usize {
+        self.generic.mission_id(mission)
+    }
+
+    fn stay_in(
+        &self,
+        trip_before: &Self::Trip,
+        criteria_before: &Self::Criteria,
+    ) -> Option<(Self::Trip, Self::Criteria)> {
+        self.generic.stay_in(trip_before, criteria_before)
+    }
+}
+
+impl<'data, 'model, 'outer, Data> RequestIters<'outer> for Request<'data, 'model, Data>
+where
+    Data: DataTrait + DataIters<'outer>,
+    Data::Transfer: 'outer,
+    Data::Stop: 'outer,
+{
+    type Arrivals = Arrivals;
+    fn arrivals(&'outer self) -> Self::Arrivals {
+        self.generic.arrivals()
+    }
+
+    type Departures = Departures;
+    fn departures(&'outer self) -> Self::Departures {
+        self.generic.departures()
+    }
+
+    type MissionsAtStop = Data::MissionsAtStop;
+    fn missions_at(&'outer self, stop: &Self::Stop) -> Self::MissionsAtStop {
+        self.generic.missions_at(stop)
+    }
+
+    type TransfersAtStop = super::TransferAtStop<'outer, Data>;
+    fn transfers_at(
+        &'outer self,
+        from_stop: &Self::Stop,
+        criteria: &Self::Criteria,
+    ) -> Self::TransfersAtStop {
+        self.generic.transfers_at(from_stop, criteria)
+    }
+
+    type TripsOfMission = Data::TripsOfMission;
+    fn trips_of(&'outer self, mission: &Self::Mission) -> Self::TripsOfMission {
+        self.generic.trips_of(mission)
+    }
+}
+
+impl<'data, 'model, Data> RequestWithIters for Request<'data, 'model, Data> where Data: DataWithIters
+{}
+
+use crate::{engine::engine_interface::Journey as PTJourney, response};
+
+impl<'data, 'model, Data> RequestIO<'data, 'model, Data> for Request<'data, 'model, Data>
+where
+    Data: DataTrait,
+{
+    fn new(
+        model: &'model ModelRefs<'model>,
+        transit_data: &'data Data,
+        request_input: &RequestInput,
+    ) -> Result<Self, BadRequest>
+    where
+        Self: Sized,
+    {
+        let generic_result = GenericArriveBeforeRequest::new(model, transit_data, request_input);
+        generic_result.map(|generic| Self { generic })
+    }
+
+    fn data(&self) -> &Data {
+        self.generic.transit_data
+    }
+
+    fn create_response<T>(
+        &self,
+        pt_journey: &PTJourney<T>,
+    ) -> Result<response::Journey<Data>, response::JourneyError<Data>>
+    where
+        Self: Sized,
+        T: RequestTypes<
+            Stop = Self::Stop,
+            Mission = Self::Mission,
+            Position = Self::Position,
+            Trip = Self::Trip,
+            Transfer = Self::Transfer,
+            Arrival = Self::Arrival,
+            Departure = Self::Departure,
+            Criteria = Self::Criteria,
+        >,
+    {
+        self.generic.create_arrive_before_response(pt_journey)
+    }
+}
+
+impl<'data, 'model, Data> RequestDebug for Request<'data, 'model, Data>
+where
+    Data: DataTrait,
+{
+    fn stop_name(&self, stop: &Self::Stop) -> String {
+        self.generic.stop_name(stop)
+    }
+
+    fn trip_name(&self, trip: &Self::Trip) -> String {
+        self.generic.trip_name(trip)
+    }
+
+    fn mission_name(&self, mission: &Self::Mission) -> String {
+        self.generic.mission_name(mission)
+    }
+
+    fn position_name(&self, position: &Self::Position, mission: &Self::Mission) -> String {
+        self.generic.position_name(position, mission)
+    }
+}

--- a/src/request/depart_after.rs
+++ b/src/request/depart_after.rs
@@ -41,6 +41,7 @@ pub mod robustness_comparator;
 use crate::{
     loads_data::LoadsCount,
     models::ModelRefs,
+    robustness::Uncertainty,
     time::{PositiveDuration, SecondsSinceDatasetUTCStart},
     transit_data::data_interface::DataIters,
     RealTimeLevel,
@@ -167,7 +168,7 @@ where
             connections,
             *arrival_fallback_duration,
             pt_journey.criteria_at_arrival.loads_count.clone(),
-            pt_journey.criteria_at_arrival.max_regularity,
+            pt_journey.criteria_at_arrival.uncertainty,
             self.transit_data,
             self.real_time_level,
         )
@@ -239,7 +240,7 @@ where
             fallback_duration: waiting_criteria.fallback_duration,
             transfers_duration: waiting_criteria.transfers_duration,
             loads_count: waiting_criteria.loads_count.add(load),
-            max_regularity: std::cmp::max(regularity, waiting_criteria.max_regularity),
+            uncertainty: waiting_criteria.uncertainty.extend(regularity),
         };
         Some(new_criteria)
     }
@@ -258,7 +259,7 @@ where
             fallback_duration: criteria.fallback_duration,
             transfers_duration: criteria.transfers_duration,
             loads_count: criteria.loads_count.clone(),
-            max_regularity: std::cmp::max(regularity, criteria.max_regularity),
+            uncertainty: criteria.uncertainty.extend(regularity),
         };
         Some((next_trip, new_criteria))
     }
@@ -286,7 +287,7 @@ where
                     fallback_duration: waiting_criteria.fallback_duration,
                     transfers_duration: waiting_criteria.transfers_duration,
                     loads_count: waiting_criteria.loads_count.add(load),
-                    max_regularity: std::cmp::max(regularity, waiting_criteria.max_regularity),
+                    uncertainty: waiting_criteria.uncertainty.extend(regularity),
                 };
                 (trip, new_criteria)
             })
@@ -310,7 +311,7 @@ where
                 fallback_duration: onboard_criteria.fallback_duration,
                 transfers_duration: onboard_criteria.transfers_duration,
                 loads_count: onboard_criteria.loads_count.clone(),
-                max_regularity: onboard_criteria.max_regularity,
+                uncertainty: onboard_criteria.uncertainty,
             })
     }
 
@@ -328,7 +329,7 @@ where
             fallback_duration: criteria.fallback_duration,
             transfers_duration: criteria.transfers_duration,
             loads_count: criteria.loads_count.add(load),
-            max_regularity: criteria.max_regularity,
+            uncertainty: criteria.uncertainty,
         }
     }
 
@@ -342,7 +343,7 @@ where
             fallback_duration: *fallback_duration,
             transfers_duration: PositiveDuration::zero(),
             loads_count: LoadsCount::zero(),
-            max_regularity: crate::robustness::Regularity::Rare,
+            uncertainty: Uncertainty::zero(),
         };
         (stop.clone(), criteria)
     }
@@ -361,7 +362,7 @@ where
             fallback_duration: criteria.fallback_duration + *arrival_duration,
             transfers_duration: criteria.transfers_duration,
             loads_count: criteria.loads_count.clone(),
-            max_regularity: criteria.max_regularity,
+            uncertainty: criteria.uncertainty,
         }
     }
 
@@ -539,7 +540,7 @@ where
                 fallback_duration: self.criteria.fallback_duration,
                 transfers_duration: self.criteria.transfers_duration + durations.walking_duration,
                 loads_count: self.criteria.loads_count.clone(),
-                max_regularity: self.criteria.max_regularity,
+                uncertainty: self.criteria.uncertainty,
             };
             (stop.clone(), new_criteria, transfer.clone())
         })

--- a/src/request/depart_after.rs
+++ b/src/request/depart_after.rs
@@ -167,6 +167,7 @@ where
             connections,
             *arrival_fallback_duration,
             pt_journey.criteria_at_arrival.loads_count.clone(),
+            pt_journey.criteria_at_arrival.max_regularity,
             self.transit_data,
             self.real_time_level,
         )

--- a/src/request/depart_after/robustness_comparator.rs
+++ b/src/request/depart_after/robustness_comparator.rs
@@ -71,18 +71,15 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
         let lower_nb_of_legs = u32::from(lower.nb_of_legs);
         let upper_nb_of_legs = u32::from(upper.nb_of_legs);
 
-        let lower_uncertainty_level = u32::from(lower.uncertainty.level());
-        let upper_uncertainty_level = u32::from(upper.uncertainty.level());
-
         lower.time + arrival_penalty * lower_nb_of_legs
             <= upper.time + arrival_penalty * upper_nb_of_legs
-            //&& lower.uncertainty <= upper.uncertainty
+            && lower.uncertainty <= upper.uncertainty
             && lower.fallback_duration
                 + lower.transfers_duration
-                + walking_penalty * lower_uncertainty_level
+                + walking_penalty * lower_nb_of_legs
                 <= upper.fallback_duration
                     + upper.transfers_duration
-                    + walking_penalty * upper_uncertainty_level
+                    + walking_penalty * upper_nb_of_legs
     }
 
     fn can_be_discarded(

--- a/src/request/depart_after/robustness_comparator.rs
+++ b/src/request/depart_after/robustness_comparator.rs
@@ -1,0 +1,299 @@
+// Copyright  (C) 2020, Hove and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+// the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+// powered by Hove (www.kisio.com).
+// Help us simplify mobility and open public transport:
+// a non ending quest to the responsive locomotion way of traveling!
+//
+// This contribution is a part of the research and development work of the
+// IVA Project which aims to enhance traveler information and is carried out
+// under the leadership of the Technological Research Institute SystemX,
+// with the partnership and support of the transport organization authority
+// Ile-De-France Mobilités (IDFM), SNCF, and public funds
+// under the scope of the French Program "Investissements d’Avenir".
+//
+// LICENCE: This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+use crate::{
+    engine::engine_interface::{
+        BadRequest, Request as RequestTrait, RequestDebug, RequestIO, RequestInput, RequestIters,
+        RequestTypes, RequestWithIters,
+    },
+    models::ModelRefs,
+    transit_data::data_interface::{Data as DataTrait, DataIters, DataWithIters, TransitTypes},
+};
+
+use super::{Arrival, Arrivals, Criteria, Departure, Departures, GenericDepartAfterRequest};
+
+pub struct Request<'data, 'model, Data: DataTrait> {
+    generic: GenericDepartAfterRequest<'data, 'model, Data>,
+}
+
+impl<'data, 'model, Data: DataTrait> TransitTypes for Request<'data, 'model, Data> {
+    type Stop = Data::Stop;
+    type Mission = Data::Mission;
+    type Position = Data::Position;
+    type Trip = Data::Trip;
+    type Transfer = Data::Transfer;
+}
+
+impl<'data, 'model, Data: DataTrait> RequestTypes for Request<'data, 'model, Data> {
+    type Departure = Departure;
+    type Arrival = Arrival;
+    type Criteria = Criteria;
+}
+
+impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Data> {
+    fn is_lower(&self, lower: &Self::Criteria, upper: &Self::Criteria) -> bool {
+        let arrival_penalty = self.generic.leg_arrival_penalty();
+        let walking_penalty = self.generic.leg_walking_penalty();
+
+        let lower_nb_of_legs = u32::from(lower.nb_of_legs);
+        let upper_nb_of_legs = u32::from(upper.nb_of_legs);
+
+        lower.time + arrival_penalty * lower_nb_of_legs
+            <= upper.time + arrival_penalty * upper_nb_of_legs
+            && lower.max_regularity >= upper.max_regularity
+            && lower.fallback_duration
+                + lower.transfers_duration
+                + walking_penalty * lower_nb_of_legs
+                <= upper.fallback_duration
+                    + upper.transfers_duration
+                    + walking_penalty * upper_nb_of_legs
+    }
+
+    fn can_be_discarded(
+        &self,
+        partial_journey_criteria: &Self::Criteria,
+        complete_journey_criteria: &Self::Criteria,
+    ) -> bool {
+        self.generic
+            .can_be_discarded(partial_journey_criteria, complete_journey_criteria)
+    }
+
+    fn is_valid(&self, criteria: &Self::Criteria) -> bool {
+        self.generic.is_valid(criteria)
+    }
+
+    fn board_and_ride(
+        &self,
+        position: &Self::Position,
+        trip: &Self::Trip,
+        waiting_criteria: &Self::Criteria,
+    ) -> Option<Self::Criteria> {
+        self.generic
+            .board_and_ride(position, trip, waiting_criteria)
+    }
+
+    fn best_trip_to_board(
+        &self,
+        position: &Self::Position,
+        mission: &Self::Mission,
+        waiting_criteria: &Self::Criteria,
+    ) -> Option<(Self::Trip, Self::Criteria)> {
+        self.generic
+            .best_trip_to_board(position, mission, waiting_criteria)
+    }
+
+    fn debark(
+        &self,
+        trip: &Self::Trip,
+        position: &Self::Position,
+        onboard_criteria: &Self::Criteria,
+    ) -> Option<Self::Criteria> {
+        self.generic.debark(trip, position, onboard_criteria)
+    }
+
+    fn ride(
+        &self,
+        trip: &Self::Trip,
+        position: &Self::Position,
+        criteria: &Self::Criteria,
+    ) -> Self::Criteria {
+        self.generic.ride(trip, position, criteria)
+    }
+
+    fn depart(&self, departure: &Self::Departure) -> (Self::Stop, Self::Criteria) {
+        self.generic.depart(departure)
+    }
+
+    fn arrive(&self, arrival: &Self::Arrival, criteria: &Self::Criteria) -> Self::Criteria {
+        self.generic.arrive(arrival, criteria)
+    }
+
+    fn arrival_stop(&self, arrival: &Self::Arrival) -> Self::Stop {
+        self.generic.arrival_stop(arrival)
+    }
+
+    fn is_upstream(
+        &self,
+        upstream: &Self::Position,
+        downstream: &Self::Position,
+        mission: &Self::Mission,
+    ) -> bool {
+        self.generic.is_upstream(upstream, downstream, mission)
+    }
+
+    fn next_on_mission(
+        &self,
+        stop: &Self::Position,
+        mission: &Self::Mission,
+    ) -> Option<Self::Position> {
+        self.generic.next_on_mission(stop, mission)
+    }
+
+    fn mission_of(&self, trip: &Self::Trip) -> Self::Mission {
+        self.generic.mission_of(trip)
+    }
+
+    fn stop_of(&self, position: &Self::Position, mission: &Self::Mission) -> Self::Stop {
+        self.generic.stop_of(position, mission)
+    }
+
+    fn nb_of_stops(&self) -> usize {
+        self.generic.nb_of_stops()
+    }
+
+    fn stop_id(&self, stop: &Self::Stop) -> usize {
+        self.generic.stop_id(stop)
+    }
+
+    fn nb_of_missions(&self) -> usize {
+        self.generic.nb_of_missions()
+    }
+
+    fn mission_id(&self, mission: &Self::Mission) -> usize {
+        self.generic.mission_id(mission)
+    }
+
+    fn stay_in(
+        &self,
+        trip_before: &Self::Trip,
+        criteria_before: &Self::Criteria,
+    ) -> Option<(Self::Trip, Self::Criteria)> {
+        self.generic.stay_in(trip_before, criteria_before)
+    }
+}
+
+impl<'data, 'model, 'outer, Data> RequestIters<'outer> for Request<'data, 'model, Data>
+where
+    Data: DataTrait + DataIters<'outer>,
+    Data::Transfer: 'outer,
+    Data::Stop: 'outer,
+{
+    type Arrivals = Arrivals;
+    fn arrivals(&'outer self) -> Self::Arrivals {
+        self.generic.arrivals()
+    }
+
+    type Departures = Departures;
+    fn departures(&'outer self) -> Self::Departures {
+        self.generic.departures()
+    }
+
+    type MissionsAtStop = Data::MissionsAtStop;
+    fn missions_at(&'outer self, stop: &Self::Stop) -> Self::MissionsAtStop {
+        self.generic.missions_at(stop)
+    }
+
+    type TransfersAtStop = super::TransferAtStop<'outer, Data>;
+    fn transfers_at(
+        &'outer self,
+        from_stop: &Self::Stop,
+        criteria: &Self::Criteria,
+    ) -> Self::TransfersAtStop {
+        self.generic.transfers_at(from_stop, criteria)
+    }
+
+    type TripsOfMission = Data::TripsOfMission;
+    fn trips_of(&'outer self, mission: &Self::Mission) -> Self::TripsOfMission {
+        self.generic.trips_of(mission)
+    }
+}
+
+impl<'data, 'model, Data> RequestWithIters for Request<'data, 'model, Data> where Data: DataWithIters
+{}
+
+use crate::{engine::engine_interface::Journey as PTJourney, response};
+
+impl<'data, 'model, Data> RequestIO<'data, 'model, Data> for Request<'data, 'model, Data>
+where
+    Data: DataTrait,
+{
+    fn new(
+        model: &'model ModelRefs<'model>,
+        transit_data: &'data Data,
+        request_input: &RequestInput,
+    ) -> Result<Self, BadRequest>
+    where
+        Self: Sized,
+    {
+        let generic_result = GenericDepartAfterRequest::new(model, transit_data, request_input);
+        generic_result.map(|generic| Self { generic })
+    }
+
+    fn data(&self) -> &Data {
+        self.generic.transit_data
+    }
+
+    fn create_response<T>(
+        &self,
+        pt_journey: &PTJourney<T>,
+    ) -> Result<response::Journey<Data>, response::JourneyError<Data>>
+    where
+        Self: Sized,
+        T: RequestTypes<
+            Stop = Self::Stop,
+            Mission = Self::Mission,
+            Position = Self::Position,
+            Trip = Self::Trip,
+            Transfer = Self::Transfer,
+            Arrival = Self::Arrival,
+            Departure = Self::Departure,
+            Criteria = Self::Criteria,
+        >,
+    {
+        self.generic.create_response(pt_journey)
+    }
+}
+
+impl<'data, 'model, Data> RequestDebug for Request<'data, 'model, Data>
+where
+    Data: DataTrait,
+{
+    fn stop_name(&self, stop: &Self::Stop) -> String {
+        self.generic.stop_name(stop)
+    }
+
+    fn trip_name(&self, trip: &Self::Trip) -> String {
+        self.generic.trip_name(trip)
+    }
+
+    fn mission_name(&self, mission: &Self::Mission) -> String {
+        self.generic.mission_name(mission)
+    }
+
+    fn position_name(&self, position: &Self::Position, mission: &Self::Mission) -> String {
+        self.generic.position_name(position, mission)
+    }
+}

--- a/src/request/depart_after/robustness_comparator.rs
+++ b/src/request/depart_after/robustness_comparator.rs
@@ -73,7 +73,7 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
 
         lower.time + arrival_penalty * lower_nb_of_legs
             <= upper.time + arrival_penalty * upper_nb_of_legs
-            && lower.max_regularity >= upper.max_regularity
+            && lower.uncertainty.is_lower(&upper.uncertainty)
             && lower.fallback_duration
                 + lower.transfers_duration
                 + walking_penalty * lower_nb_of_legs

--- a/src/request/depart_after/robustness_comparator.rs
+++ b/src/request/depart_after/robustness_comparator.rs
@@ -73,7 +73,7 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
 
         lower.time + arrival_penalty * lower_nb_of_legs
             <= upper.time + arrival_penalty * upper_nb_of_legs
-            && lower.uncertainty.is_lower(&upper.uncertainty)
+            && lower.uncertainty <= upper.uncertainty
             && lower.fallback_duration
                 + lower.transfers_duration
                 + walking_penalty * lower_nb_of_legs

--- a/src/request/depart_after/robustness_comparator.rs
+++ b/src/request/depart_after/robustness_comparator.rs
@@ -71,15 +71,18 @@ impl<'data, 'model, Data: DataTrait> RequestTrait for Request<'data, 'model, Dat
         let lower_nb_of_legs = u32::from(lower.nb_of_legs);
         let upper_nb_of_legs = u32::from(upper.nb_of_legs);
 
+        let lower_uncertainty_level = u32::from(lower.uncertainty.level());
+        let upper_uncertainty_level = u32::from(upper.uncertainty.level());
+
         lower.time + arrival_penalty * lower_nb_of_legs
             <= upper.time + arrival_penalty * upper_nb_of_legs
-            && lower.uncertainty <= upper.uncertainty
+            //&& lower.uncertainty <= upper.uncertainty
             && lower.fallback_duration
                 + lower.transfers_duration
-                + walking_penalty * lower_nb_of_legs
+                + walking_penalty * lower_uncertainty_level
                 <= upper.fallback_duration
                     + upper.transfers_duration
-                    + walking_penalty * upper_nb_of_legs
+                    + walking_penalty * upper_uncertainty_level
     }
 
     fn can_be_discarded(

--- a/src/request/generic_request.rs
+++ b/src/request/generic_request.rs
@@ -37,7 +37,7 @@
 use crate::{
     loads_data::LoadsCount,
     models::ModelRefs,
-    robustness::Regularity,
+    robustness::{Regularity, Uncertainty},
     time::{Calendar, PositiveDuration, SecondsSinceDatasetUTCStart},
     timetables::generic_timetables,
     transit_data::{self, data_interface::TransitTypes},
@@ -104,7 +104,7 @@ pub struct Criteria {
     pub(super) fallback_duration: PositiveDuration,
     pub(super) transfers_duration: PositiveDuration,
     pub(super) loads_count: LoadsCount,
-    pub(super) max_regularity: Regularity,
+    pub(super) uncertainty: Uncertainty,
 }
 
 pub struct RequestTypes {}

--- a/src/request/generic_request.rs
+++ b/src/request/generic_request.rs
@@ -37,6 +37,7 @@
 use crate::{
     loads_data::LoadsCount,
     models::ModelRefs,
+    robustness::Regularity,
     time::{Calendar, PositiveDuration, SecondsSinceDatasetUTCStart},
     timetables::generic_timetables,
     transit_data::{self, data_interface::TransitTypes},
@@ -103,6 +104,7 @@ pub struct Criteria {
     pub(super) fallback_duration: PositiveDuration,
     pub(super) transfers_duration: PositiveDuration,
     pub(super) loads_count: LoadsCount,
+    pub(super) max_regularity: Regularity,
 }
 
 pub struct RequestTypes {}

--- a/src/request/generic_request.rs
+++ b/src/request/generic_request.rs
@@ -37,7 +37,7 @@
 use crate::{
     loads_data::LoadsCount,
     models::ModelRefs,
-    robustness::{Regularity, Uncertainty},
+    robustness::Uncertainty,
     time::{Calendar, PositiveDuration, SecondsSinceDatasetUTCStart},
     timetables::generic_timetables,
     transit_data::{self, data_interface::TransitTypes},

--- a/src/response.rs
+++ b/src/response.rs
@@ -37,7 +37,7 @@
 use crate::{
     loads_data::LoadsCount,
     models::{ModelRefs, StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
-    robustness::Regularity,
+    robustness::{Regularity, Uncertainty},
     time::{PositiveDuration, SecondsSinceDatasetUTCStart},
     RealTimeLevel,
 };
@@ -57,7 +57,7 @@ pub struct Response {
     pub connections: Vec<(TransferSection, WaitingSection, VehicleSection)>,
     pub arrival: ArrivalSection,
     pub loads_count: LoadsCount,
-    pub max_regularity: Regularity,
+    pub uncertainty: Uncertainty,
     pub real_time_level: RealTimeLevel,
 }
 
@@ -129,7 +129,7 @@ pub struct Journey<Data: DataTrait> {
     pub(crate) connections: Vec<(Data::Transfer, VehicleLeg<Data>)>,
     pub(crate) arrival_fallback_duration: PositiveDuration,
     pub(crate) loads_count: LoadsCount,
-    pub(crate) max_regularity: Regularity,
+    pub(crate) uncertainty: Uncertainty,
     pub(crate) real_time_level: RealTimeLevel,
 }
 #[derive(Debug, Clone)]
@@ -207,7 +207,7 @@ where
         connections: impl Iterator<Item = (Data::Transfer, VehicleLeg<Data>)>,
         arrival_fallback_duration: PositiveDuration,
         loads_count: LoadsCount,
-        max_regularity: Regularity,
+        uncertainty: Uncertainty,
         data: &Data,
         real_time_level: RealTimeLevel,
     ) -> Result<Self, BadJourney<Data>> {
@@ -218,7 +218,7 @@ where
             arrival_fallback_duration,
             connections: connections.collect(),
             loads_count,
-            max_regularity,
+            uncertainty,
             real_time_level,
         };
 
@@ -433,7 +433,7 @@ where
             self.arrival_fallback_duration
         )?;
         writeln!(writer, "Loads : {}", self.loads_count)?;
-        writeln!(writer, "Robustness : {}", self.max_regularity)?;
+        writeln!(writer, "Uncertainty : {:?}", self.uncertainty)?;
 
         let departure_datetime = data.to_naive_datetime(self.departure_datetime);
         writeln!(
@@ -499,7 +499,7 @@ impl<Data: DataTrait> Journey<Data> {
             connections: self.connections(data).collect(),
             arrival: self.arrival_section(data),
             loads_count: self.loads_count.clone(),
-            max_regularity: self.max_regularity,
+            uncertainty: self.uncertainty,
             real_time_level: self.real_time_level,
         }
     }
@@ -831,7 +831,7 @@ impl Response {
             write_duration(self.arrival.duration_in_seconds())
         )?;
         writeln!(writer, "Loads : {}", self.loads_count)?;
-        writeln!(writer, "Robustness : {}", self.max_regularity)?;
+        writeln!(writer, "Uncertainty : {:?}", self.uncertainty)?;
 
         writeln!(
             writer,

--- a/src/response.rs
+++ b/src/response.rs
@@ -37,6 +37,7 @@
 use crate::{
     loads_data::LoadsCount,
     models::{ModelRefs, StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
+    robustness::Regularity,
     time::{PositiveDuration, SecondsSinceDatasetUTCStart},
     RealTimeLevel,
 };
@@ -56,6 +57,7 @@ pub struct Response {
     pub connections: Vec<(TransferSection, WaitingSection, VehicleSection)>,
     pub arrival: ArrivalSection,
     pub loads_count: LoadsCount,
+    pub max_regularity: Regularity,
     pub real_time_level: RealTimeLevel,
 }
 
@@ -127,6 +129,7 @@ pub struct Journey<Data: DataTrait> {
     pub(crate) connections: Vec<(Data::Transfer, VehicleLeg<Data>)>,
     pub(crate) arrival_fallback_duration: PositiveDuration,
     pub(crate) loads_count: LoadsCount,
+    pub(crate) max_regularity: Regularity,
     pub(crate) real_time_level: RealTimeLevel,
 }
 #[derive(Debug, Clone)]
@@ -204,6 +207,7 @@ where
         connections: impl Iterator<Item = (Data::Transfer, VehicleLeg<Data>)>,
         arrival_fallback_duration: PositiveDuration,
         loads_count: LoadsCount,
+        max_regularity: Regularity,
         data: &Data,
         real_time_level: RealTimeLevel,
     ) -> Result<Self, BadJourney<Data>> {
@@ -214,6 +218,7 @@ where
             arrival_fallback_duration,
             connections: connections.collect(),
             loads_count,
+            max_regularity,
             real_time_level,
         };
 
@@ -428,6 +433,7 @@ where
             self.arrival_fallback_duration
         )?;
         writeln!(writer, "Loads : {}", self.loads_count)?;
+        writeln!(writer, "Robustness : {}", self.max_regularity)?;
 
         let departure_datetime = data.to_naive_datetime(self.departure_datetime);
         writeln!(
@@ -493,6 +499,7 @@ impl<Data: DataTrait> Journey<Data> {
             connections: self.connections(data).collect(),
             arrival: self.arrival_section(data),
             loads_count: self.loads_count.clone(),
+            max_regularity: self.max_regularity,
             real_time_level: self.real_time_level,
         }
     }
@@ -824,6 +831,7 @@ impl Response {
             write_duration(self.arrival.duration_in_seconds())
         )?;
         writeln!(writer, "Loads : {}", self.loads_count)?;
+        writeln!(writer, "Robustness : {}", self.max_regularity)?;
 
         writeln!(
             writer,

--- a/src/response.rs
+++ b/src/response.rs
@@ -37,7 +37,7 @@
 use crate::{
     loads_data::LoadsCount,
     models::{ModelRefs, StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
-    robustness::{Regularity, Uncertainty},
+    robustness::Uncertainty,
     time::{PositiveDuration, SecondsSinceDatasetUTCStart},
     RealTimeLevel,
 };
@@ -433,7 +433,7 @@ where
             self.arrival_fallback_duration
         )?;
         writeln!(writer, "Loads : {}", self.loads_count)?;
-        writeln!(writer, "Uncertainty : {:?}", self.uncertainty)?;
+        writeln!(writer, "Uncertainty : {}", self.uncertainty)?;
 
         let departure_datetime = data.to_naive_datetime(self.departure_datetime);
         writeln!(
@@ -831,7 +831,7 @@ impl Response {
             write_duration(self.arrival.duration_in_seconds())
         )?;
         writeln!(writer, "Loads : {}", self.loads_count)?;
-        writeln!(writer, "Uncertainty : {:?}", self.uncertainty)?;
+        writeln!(writer, "Uncertainty : {}", self.uncertainty)?;
 
         writeln!(
             writer,

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -41,9 +41,10 @@ pub enum Regularity {
 impl Regularity {
     pub fn new(physical_mode_name: &str) -> Self {
         match physical_mode_name {
-            "Bus" | "Funicular" | "Coach" | "Train" | "LongDistanceTrain" => Regularity::Rare,
-
-            "LocalTrain" | "RapidTransit" | "Tramway" | "RailShuttle" => Regularity::Intermittent,
+            "Bus" | "Funicular" | "Coach" | "Train" | "LongDistanceTrain" | "Air" | "Boat"
+            | "Ferry" | "SuspendedCableCar" => Regularity::Rare,
+            "LocalTrain" | "RapidTransit" | "Tramway" | "RailShuttle" | "BusRapidTransit"
+            | "Shuttle" => Regularity::Intermittent,
             "Metro" => Regularity::Frequent,
             // unknown physical mode, let's default to Rare
             _ => {

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -27,7 +27,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Regularity {
     Rare,
     Intermittent,
@@ -46,5 +46,25 @@ impl Regularity {
             // unknown physical mode, let's default to Rare
             _ => Regularity::Rare,
         }
+    }
+
+    fn level(&self) -> u8 {
+        match &self {
+            Regularity::Rare => 0,
+            Regularity::Intermittent => 1,
+            Regularity::Frequent => 2,
+        }
+    }
+}
+
+impl Ord for Regularity {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        Ord::cmp(&self.level(), &other.level())
+    }
+}
+
+impl PartialOrd for Regularity {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -27,8 +27,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use transit_model::objects::PhysicalMode;
-
+#[derive(Debug, Copy, Clone)]
 pub enum Regularity {
     Rare,
     Intermittent,
@@ -36,15 +35,16 @@ pub enum Regularity {
 }
 
 impl Regularity {
-    pub fn new(physical_mode: &PhysicalMode) -> Option<Self> {
-        match physical_mode.id.as_str() {
-            "physical_mode:Bus" | "physical_mode:Funicular" => Some(Regularity::Rare),
+    pub fn new(physical_mode_name: &str) -> Self {
+        match physical_mode_name {
+            "physical_mode:Bus" | "physical_mode:Funicular" => Regularity::Rare,
 
             "physical_mode:LocalTrain" | "physical_mode:RapidTransit" | "physical_mode:Tramway" => {
-                Some(Regularity::Intermittent)
+                Regularity::Intermittent
             }
-            "physical_mode:Metro" => Some(Regularity::Frequent),
-            _ => None,
+            "physical_mode:Metro" => Regularity::Frequent,
+            // unknown physical mode, let's default to Rare
+            _ => Regularity::Rare,
         }
     }
 }

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -42,7 +42,7 @@ pub enum Regularity {
 impl Regularity {
     pub fn new(physical_mode_name: &str) -> Self {
         match physical_mode_name {
-            "Bus" | "Funicular" => Regularity::Rare,
+            "Bus" | "Funicular" | "Coach" | "LongDistanceTrain" => Regularity::Rare,
 
             "Train" | "LocalTrain" | "RapidTransit" | "Tramway" | "RailShuttle" => {
                 Regularity::Intermittent

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -83,23 +83,19 @@ impl Uncertainty {
         let delta = match (self.last_vehicle_regularity, next_vehicle_regularity) {
             (_, Frequent) => 1,
 
-            (None, Intermittent) | (Some(Frequent), Intermittent) => 2,
+            (None | Some(Frequent), Intermittent) => 2,
 
-            (None, Rare) | (Some(Frequent), Rare) => 3,
+            (None | Some(Frequent), Rare) => 3,
 
-            (Some(Intermittent), Intermittent) | (Some(Rare), Intermittent) => 5,
+            (Some(Rare | Intermittent), Intermittent) => 5,
 
-            (Some(Intermittent), Rare) | (Some(Rare), Rare) => 10,
+            (Some(Rare | Intermittent), Rare) => 10,
         };
         let level = self.level.saturating_add(delta);
         Self {
             level,
             last_vehicle_regularity: Some(next_vehicle_regularity),
         }
-    }
-
-    pub fn is_lower(&self, other: &Self) -> bool {
-        self.level <= other.level
     }
 }
 
@@ -111,7 +107,7 @@ impl Ord for Uncertainty {
 
 impl PartialOrd for Uncertainty {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -27,7 +27,6 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use core::panic;
 use std::fmt::Display;
 
 use tracing::debug;
@@ -42,11 +41,9 @@ pub enum Regularity {
 impl Regularity {
     pub fn new(physical_mode_name: &str) -> Self {
         match physical_mode_name {
-            "Bus" | "Funicular" | "Coach" | "LongDistanceTrain" => Regularity::Rare,
+            "Bus" | "Funicular" | "Coach" | "Train" | "LongDistanceTrain" => Regularity::Rare,
 
-            "Train" | "LocalTrain" | "RapidTransit" | "Tramway" | "RailShuttle" => {
-                Regularity::Intermittent
-            }
+            "LocalTrain" | "RapidTransit" | "Tramway" | "RailShuttle" => Regularity::Intermittent,
             "Metro" => Regularity::Frequent,
             // unknown physical mode, let's default to Rare
             _ => {

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -27,6 +27,11 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
+use core::panic;
+use std::fmt::Display;
+
+use tracing::debug;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Regularity {
     Rare,
@@ -37,18 +42,21 @@ pub enum Regularity {
 impl Regularity {
     pub fn new(physical_mode_name: &str) -> Self {
         match physical_mode_name {
-            "physical_mode:Bus" | "physical_mode:Funicular" => Regularity::Rare,
+            "Bus" | "Funicular" => Regularity::Rare,
 
-            "physical_mode:LocalTrain" | "physical_mode:RapidTransit" | "physical_mode:Tramway" => {
+            "Train" | "LocalTrain" | "RapidTransit" | "Tramway" | "RailShuttle" => {
                 Regularity::Intermittent
             }
-            "physical_mode:Metro" => Regularity::Frequent,
+            "Metro" => Regularity::Frequent,
             // unknown physical mode, let's default to Rare
-            _ => Regularity::Rare,
+            _ => {
+                debug!("unknown physical mode {}", physical_mode_name);
+                Regularity::Rare
+            }
         }
     }
 
-    fn level(&self) -> u8 {
+    fn level(self) -> u8 {
         match &self {
             Regularity::Rare => 0,
             Regularity::Intermittent => 1,
@@ -66,5 +74,15 @@ impl Ord for Regularity {
 impl PartialOrd for Regularity {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl Display for Regularity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Regularity::Frequent => write!(f, "frequent"),
+            Regularity::Intermittent => write!(f, "intermittent"),
+            Regularity::Rare => write!(f, "rare"),
+        }
     }
 }

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -102,3 +102,9 @@ impl Uncertainty {
         self.level <= other.level
     }
 }
+
+impl Display for Uncertainty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.level)
+    }
+}

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -79,6 +79,10 @@ impl Uncertainty {
         }
     }
 
+    pub fn level(&self) -> u8 {
+        self.level
+    }
+
     pub fn extend(&self, next_vehicle_regularity: Regularity) -> Self {
         use Regularity::{Frequent, Intermittent, Rare};
         let delta = match (self.last_vehicle_regularity, next_vehicle_regularity) {

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -103,6 +103,18 @@ impl Uncertainty {
     }
 }
 
+impl Ord for Uncertainty {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.level.cmp(&other.level)
+    }
+}
+
+impl PartialOrd for Uncertainty {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
 impl Display for Uncertainty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.level)

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -65,6 +65,10 @@ impl Display for Regularity {
     }
 }
 
+// We will improve the "robustness" of a journey
+// by minimizing its "uncertainty" level : and indicator that increase each time a vehicle is boarded.
+// The uncertainty increment depends on the regularity of both the previous vehicle (if any) and the vehicle to be boarded.
+// That's why it is convenient to store the last_vehicle_regularity inside the Uncertainty struct
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Uncertainty {
     level: u8,
@@ -83,6 +87,20 @@ impl Uncertainty {
         self.level
     }
 
+    // The uncertainty increment depends on the regularity of both the previous vehicle (if any) and the vehicle to be boarded.
+    // In a nutshell, the idea is :
+    // - if there is no previous vehicle, or the previous vehicle is Frequent, the uncertainty increases a little, depending on the regularity of the vehicle to be boarded
+    // - if the previous vehicle is Rare of Intermittent, the uncertainty increases a lot if the next vehicle is also Rare of Intermittent, and just a little for a Frequent one
+    //
+    // Uncertainty increments by previous vehicle regularity (vertical) and next vehicle regularity (horizontal) :
+    //
+    // |                   |   Rare    |  Intermittent  |  Frequent  |
+    // | ----------------- | --------- | -------------- | ---------- |
+    // | Rare              |   +10     |      +5        |    +1      |
+    // | Intermittent      |   +10     |      +5        |    +1      |
+    // | Frequent          |   +3      |      +2        |    +1      |
+    // | None              |   +3      |      +2        |    +1      |
+    //
     pub fn extend(&self, next_vehicle_regularity: Regularity) -> Self {
         use Regularity::{Frequent, Intermittent, Rare};
         let delta = match (self.last_vehicle_regularity, next_vehicle_regularity) {

--- a/src/robustness.rs
+++ b/src/robustness.rs
@@ -1,0 +1,50 @@
+// Copyright  (C) 2022, Hove and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+// the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+// powered by Hove (www.kisio.com).
+// Help us simplify mobility and open public transport:
+// a non ending quest to the responsive locomotion way of traveling!
+//
+// LICENCE: This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+use transit_model::objects::PhysicalMode;
+
+pub enum Regularity {
+    Rare,
+    Intermittent,
+    Frequent,
+}
+
+impl Regularity {
+    pub fn new(physical_mode: &PhysicalMode) -> Option<Self> {
+        match physical_mode.id.as_str() {
+            "physical_mode:Bus" | "physical_mode:Funicular" => Some(Regularity::Rare),
+
+            "physical_mode:LocalTrain" | "physical_mode:RapidTransit" | "physical_mode:Tramway" => {
+                Some(Regularity::Intermittent)
+            }
+            "physical_mode:Metro" => Some(Regularity::Frequent),
+            _ => None,
+        }
+    }
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -36,7 +36,7 @@
 
 use chrono::{FixedOffset, NaiveDate};
 use std::{
-    fmt::{Display, Formatter},
+    fmt::{Debug, Display, Formatter},
     num::TryFromIntError,
 };
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -173,6 +173,14 @@ impl PositiveDuration {
         }
     }
 
+    pub fn try_from(seconds: i32) -> Option<PositiveDuration> {
+        let seconds_u32 = u32::try_from(seconds).ok()?;
+        let result = PositiveDuration {
+            seconds: seconds_u32,
+        };
+        Some(result)
+    }
+
     pub fn total_seconds(&self) -> u64 {
         u64::from(self.seconds)
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -35,7 +35,10 @@
 // www.navitia.io
 
 use chrono::{FixedOffset, NaiveDate};
-use std::fmt::{Debug, Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    num::TryFromIntError,
+};
 
 pub mod calendar;
 pub mod days_map;
@@ -140,6 +143,18 @@ impl std::str::FromStr for PositiveDuration {
     }
 }
 
+impl TryFrom<i32> for PositiveDuration {
+    type Error = TryFromIntError;
+
+    fn try_from(seconds: i32) -> Result<Self, Self::Error> {
+        let seconds_u32 = u32::try_from(seconds)?;
+        let result = PositiveDuration {
+            seconds: seconds_u32,
+        };
+        Ok(result)
+    }
+}
+
 impl<'de> serde::Deserialize<'de> for PositiveDuration {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -171,14 +186,6 @@ impl PositiveDuration {
         PositiveDuration {
             seconds: total_seconds,
         }
-    }
-
-    pub fn try_from(seconds: i32) -> Option<PositiveDuration> {
-        let seconds_u32 = u32::try_from(seconds).ok()?;
-        let result = PositiveDuration {
-            seconds: seconds_u32,
-        };
-        Some(result)
     }
 
     pub fn total_seconds(&self) -> u64 {

--- a/src/timetables/utc_timetables.rs
+++ b/src/timetables/utc_timetables.rs
@@ -37,6 +37,7 @@
 use crate::{
     loads_data::{Load, LoadsData},
     models::{StopTimeIdx, VehicleJourneyIdx},
+    robustness::Regularity,
     time::{
         calendar::DecomposeUTCResult,
         days_patterns::{DaysInPatternIter, DaysPattern, DaysPatterns},
@@ -74,6 +75,7 @@ pub struct VehicleData {
     base_days_pattern: DaysPattern,
     real_time_days_pattern: DaysPattern,
     local_zone: LocalZone,
+    regularity: Regularity,
 }
 
 impl UTCTimetables {
@@ -97,6 +99,10 @@ impl UTCTimetables {
             .vehicle_data(&trip.vehicle)
             .vehicle_journey_idx
             .clone()
+    }
+
+    pub fn regularity(&self, trip: &Trip) -> Regularity {
+        self.timetables.vehicle_data(&trip.vehicle).regularity
     }
 
     pub fn stoptime_idx(&self, position: &Position, _trip: &Trip) -> StopTimeIdx {
@@ -355,6 +361,7 @@ impl UTCTimetables {
         vehicle_journey_idx: &VehicleJourneyIdx,
         local_zone: LocalZone,
         real_time_level: RealTimeLevel,
+        regularity: Regularity,
     ) -> Result<HashMap<Mission, DaysPattern>, (VehicleTimesError, Vec<NaiveDate>)>
     where
         Stops: Iterator<Item = Stop> + ExactSizeIterator + Clone,
@@ -436,6 +443,7 @@ impl UTCTimetables {
                     base_days_pattern,
                     real_time_days_pattern,
                     local_zone,
+                    regularity,
                 };
 
                 let apply_offset = |time_in_timezoned_day: SecondsSinceTimezonedDayStart| -> SecondsSinceUTCDayStart {

--- a/src/transit_data.rs
+++ b/src/transit_data.rs
@@ -43,6 +43,7 @@ use chrono::NaiveDate;
 use crate::{
     loads_data::Load,
     models::{ModelRefs, StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
+    robustness::Regularity,
     time::{days_patterns::DaysPatterns, Calendar, PositiveDuration, SecondsSinceDatasetUTCStart},
     timetables::{
         day_to_timetable::VehicleJourneyToTimetable,
@@ -362,6 +363,10 @@ impl data_interface::Data for TransitData {
             &self.calendar,
             &self.days_patterns,
         )
+    }
+
+    fn regularity(&self, trip: &Self::Trip) -> Regularity {
+        self.timetables.regularity(trip)
     }
 
     fn to_naive_datetime(&self, seconds: SecondsSinceDatasetUTCStart) -> chrono::NaiveDateTime {

--- a/src/transit_data/data_init.rs
+++ b/src/transit_data/data_init.rs
@@ -41,6 +41,7 @@ use crate::{
         real_time_model::RealTimeModel,
         ModelRefs, StopPointIdx, TransferIdx, VehicleJourneyIdx,
     },
+    robustness::Regularity,
     time::{days_patterns::DaysPatterns, Calendar},
     timetables::{day_to_timetable::VehicleJourneyToTimetable, FlowDirection::*},
     transit_data::{data_interface::Data as DataInterface, Stop, TransitData},
@@ -411,6 +412,8 @@ impl TransitData {
             }
         });
 
+        let physical_mode_name = base_model.physical_mode_name(vehicle_journey_idx);
+        let regularity = Regularity::new(physical_mode_name);
         let vehicle_journey_idx = VehicleJourneyIdx::Base(vehicle_journey_idx);
 
         let mut local_zones: Vec<_> = stop_times.clone().map(|s| s.local_zone_id).collect();
@@ -430,6 +433,7 @@ impl TransitData {
                 vehicle_journey_idx,
                 local_zones[0],
                 RealTimeLevel::Base,
+                regularity,
             );
             let real_time_model = RealTimeModel::new();
             let model = ModelRefs {
@@ -474,6 +478,7 @@ impl TransitData {
                     vehicle_journey_idx.clone(),
                     local_zone,
                     RealTimeLevel::Base,
+                    regularity,
                 );
 
                 let real_time_model = RealTimeModel::new();

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -1,6 +1,7 @@
 use crate::{
     loads_data::Load,
     models::{StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
+    robustness::Regularity,
     time::SecondsSinceDatasetUTCStart,
 };
 use chrono::{NaiveDate, NaiveDateTime};

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -149,6 +149,8 @@ pub trait Data: TransitTypes {
     where
         Filter: Fn(&VehicleJourneyIdx) -> bool;
 
+    fn regularity(&self, trip: &Self::Trip) -> Regularity;
+
     fn to_naive_datetime(&self, seconds: SecondsSinceDatasetUTCStart) -> NaiveDateTime;
 
     fn vehicle_journey_idx(&self, trip: &Self::Trip) -> VehicleJourneyIdx;

--- a/src/transit_data/data_update.rs
+++ b/src/transit_data/data_update.rs
@@ -39,6 +39,7 @@ use tracing::error;
 use crate::{
     loads_data::LoadsData,
     models::{StopPointIdx, VehicleJourneyIdx},
+    robustness::Regularity,
     timetables::{day_to_timetable::LocalZone, InsertionError, ModifyError, RemovalError},
     transit_data::TransitData,
 };
@@ -101,6 +102,7 @@ impl TransitData {
         valid_dates: Dates,
         timezone: chrono_tz::Tz,
         vehicle_journey_idx: VehicleJourneyIdx,
+        regularity: Regularity,
     ) -> Result<(), InsertionError>
     where
         Stops: Iterator<Item = StopPointIdx> + ExactSizeIterator + Clone,
@@ -120,6 +122,7 @@ impl TransitData {
             vehicle_journey_idx,
             None,
             RealTimeLevel::RealTime,
+            regularity,
         )
     }
 
@@ -133,6 +136,7 @@ impl TransitData {
         valid_dates: Dates,
         timezone: chrono_tz::Tz,
         vehicle_journey_idx: &VehicleJourneyIdx,
+        regularity: Regularity,
     ) -> Result<(), ModifyError>
     where
         Stops: Iterator<Item = StopPointIdx> + ExactSizeIterator + Clone,
@@ -207,6 +211,7 @@ impl TransitData {
                 vehicle_journey_idx,
                 local_zone,
                 RealTimeLevel::RealTime,
+                regularity,
             );
             let timetables = match timetables {
                 Err(err) => {
@@ -256,6 +261,7 @@ impl TransitData {
         vehicle_journey_idx: VehicleJourneyIdx,
         local_zone: LocalZone,
         real_time_level: RealTimeLevel,
+        regularity: Regularity,
     ) -> Result<(), InsertionError>
     where
         Stops: Iterator<Item = StopPointIdx> + ExactSizeIterator + Clone,
@@ -320,6 +326,7 @@ impl TransitData {
                 &vehicle_journey_idx,
                 local_zone,
                 real_time_level,
+                regularity,
             )
             .map_err(|(err, dates)| {
                 InsertionError::Times(vehicle_journey_idx.clone(), real_time_level, err, dates)

--- a/src/transit_data_filtered.rs
+++ b/src/transit_data_filtered.rs
@@ -38,6 +38,7 @@ use crate::{
     filters::Filters,
     loads_data::Load,
     models::{ModelRefs, StopPointIdx, StopTimeIdx, TransferIdx, VehicleJourneyIdx},
+    robustness::Regularity,
     time::{Calendar, SecondsSinceDatasetUTCStart},
     timetables::utc_timetables,
     transit_data::{self, data_interface, data_iters, TransferDurations},

--- a/src/transit_data_filtered.rs
+++ b/src/transit_data_filtered.rs
@@ -332,6 +332,10 @@ impl data_interface::Data for TransitDataFiltered<'_, '_> {
         }
     }
 
+    fn regularity(&self, trip: &Self::Trip) -> Regularity {
+        self.transit_data.regularity(trip)
+    }
+
     fn to_naive_datetime(&self, seconds: SecondsSinceDatasetUTCStart) -> chrono::NaiveDateTime {
         self.transit_data.calendar().to_naive_datetime(seconds)
     }

--- a/stop_areas/src/lib.rs
+++ b/stop_areas/src/lib.rs
@@ -136,7 +136,7 @@ pub fn launch(config: Config) -> Result<(BaseModel, Vec<loki::Response>), Error>
         }
     };
 
-    let datetime_represent = &config.datetime_represent;
+    let datetime_represent = config.datetime_represent;
 
     let start_compute_time = SystemTime::now();
 
@@ -156,7 +156,7 @@ pub fn launch(config: Config) -> Result<(BaseModel, Vec<loki::Response>), Error>
         &request_input,
         None,
         config.comparator_type,
-        *datetime_represent,
+        datetime_represent,
     );
 
     let duration = timer::duration_since(start_compute_time);

--- a/stop_areas/src/lib.rs
+++ b/stop_areas/src/lib.rs
@@ -155,8 +155,8 @@ pub fn launch(config: Config) -> Result<(BaseModel, Vec<loki::Response>), Error>
         &model_refs,
         &request_input,
         None,
-        &config.comparator_type,
-        datetime_represent,
+        config.comparator_type,
+        *datetime_represent,
     );
 
     let duration = timer::duration_since(start_compute_time);


### PR DESCRIPTION
Introduce an "Uncertainty" indicator that increase each time a vehicle is boarded.
The uncertainty increment depends on the regularity of both the previous vehicle (if any) and the vehicle to be boarded.
The actual increments used are [here](https://github.com/hove-io/loki/blob/75463ad4f4bd91a00e6ddb93855dd5da8f38cfd8/src/robustness.rs#L81-L92).

In a nutshell, the idea is : 

- if there is no previous vehicle, or the previous vehicle is Frequent, the uncertainty increases a little, depending on the regularity of the vehicle to be boarded 
- if the previous vehicle is Rare of Intermittent, the uncertainty increases a lot if the next vehicle is also Rare of Intermittent, and just a little for a Frequent one

Uncertainty increments by previous vehicle regularity (vertical) and next vehicle regularity (horizontal) :
|                   | Rare         | Intermittent | Frequent |
| --------------- | ------------- | -------------- | --------------|
| Rare           |     +10       |      +5        |  +1           |
| Intermittent |   +10         |      +5          |  +1          |
| Frequent     |   +3          |      +2          |  +1         |
| None           |   +3         |      +2          |  +1         |


This Uncertainty becomes a third criteria (along with arrival time & walking duration) to be minimized.
This criteria is used only when client requests` _criteria = robustness`