### PR TITLE
add an http endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,7 @@ dependencies = [
  "diesel-derive-enum",
  "futures",
  "hostname",
+ "hyper",
  "lapin",
  "launch",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ vehicle_loads = []
 [dependencies]
 transit_model = "0.51"
 typed_index_collection = { version = "2", features = ["expose-inner"] }
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 chrono-tz = "0.6"
 tracing = { version = "0.1"}
 static_assertions = "1.1.0"

--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -17,3 +17,10 @@ COPY --from=builder /usr/local/cargo/bin/loki_server /usr/local/bin/loki_server
 
 VOLUME /data
 CMD ["/usr/local/bin/loki_server", "/data/loki_config.toml"]
+
+# https://docs.docker.com/engine/reference/builder/#healthcheck
+# /!\ "127.0.0.1:3000" is the default http address of loki_server
+# but it may be overriden in config file.
+# You should change the healthcheck command accordingly if that happens.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=2m \
+  CMD curl -f http://127.0.0.1:3000/health || exit 1

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -44,6 +44,9 @@ num-traits = "0.2.14"
 
 tracing = { version = "0.1", features = ["release_max_level_info"]}
 
+hyper = {version = "0.14", features = ["server", "stream"] }
+
+
 [dev-dependencies]
 shiplift = "0.7" # docker API
 tempfile = "3"

--- a/server/config_files/data_in_local_folder.toml
+++ b/server/config_files/data_in_local_folder.toml
@@ -11,6 +11,10 @@ instance_name = 'my_coverage'
 # REQUIRED
 requests_socket = 'tcp://*:30001'
 
+# http endpoint for health checks
+# defaults to "127.0.0.1:3000"
+http_address = "127.0.0.1:8080"
+
 # the format of the input files
 # can be : 'ntfs' or 'gtfs'
 # defaults to 'ntfs'

--- a/server/config_files/data_in_local_folder.toml
+++ b/server/config_files/data_in_local_folder.toml
@@ -11,9 +11,7 @@ instance_name = 'my_coverage'
 # REQUIRED
 requests_socket = 'tcp://*:30001'
 
-# http endpoint for health checks
-# defaults to "127.0.0.1:3000"
-http_address = "127.0.0.1:8080"
+
 
 # the format of the input files
 # can be : 'ntfs' or 'gtfs'
@@ -82,3 +80,15 @@ database = 'postgres://login:password@chaos_hostname:5432/chaos'
 # Optional.
 # Defaults to 1_000_000
 batch_size = 1_000_000
+
+
+# Configures an http endpoint for status and health checks
+[http]
+# http endpoint for health checks
+# defaults to "127.0.0.1:3000"
+# This will provide two routes
+#  - http://127.0.0.1:3000/status
+#  - http://127.0.0.1:3000/health
+http_address = "127.0.0.1:3000"
+
+http_request_timeout = "00:00:10"

--- a/server/src/http_worker.rs
+++ b/server/src/http_worker.rs
@@ -140,9 +140,9 @@ async fn handle_http_request(
                 http_request.method(),
                 http_request.uri().path()
             );
-            return Response::builder()
+            Response::builder()
                 .status(StatusCode::NOT_FOUND)
-                .body(Body::empty());
+                .body(Body::empty())
         }
     }
 }
@@ -154,7 +154,7 @@ async fn handle_status_request(
     let timeout = tokio::time::Duration::from_secs(3);
 
     // send a request to the status worker
-    let _ = status_request_sender
+    status_request_sender
         .send_timeout(status_response_sender, timeout)
         .await
         .map_err(|_| format_err!("Could not send request to status worker"))?;

--- a/server/src/http_worker.rs
+++ b/server/src/http_worker.rs
@@ -1,0 +1,167 @@
+// Copyright  (C) 2022, Hove and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+// the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+// powered by Hove (www.kisio.com).
+// Help us simplify mobility and open public transport:
+// a non ending quest to the responsive locomotion way of traveling!
+//
+//
+// LICENCE: This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+use anyhow::{format_err, Context, Error};
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Method, Request, Response, StatusCode};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{error, info};
+
+use crate::status_worker::Status;
+
+pub struct HttpToStatusChannel {
+    // http worker will send a oneshot::Sender thought `chan`
+    // to status worker, and will wait for the response
+    // on the oneshot::Receiver
+    pub status_request_receiver: mpsc::Receiver<oneshot::Sender<Status>>,
+}
+
+pub struct HttpWorker {
+    http_address: std::net::SocketAddr,
+    status_request_sender: mpsc::Sender<oneshot::Sender<Status>>,
+    shutdown_sender: mpsc::Sender<()>,
+}
+
+impl HttpWorker {
+    pub fn new(
+        http_address: std::net::SocketAddr,
+        shutdown_sender: mpsc::Sender<()>,
+    ) -> (Self, HttpToStatusChannel) {
+        let (status_request_sender, status_request_receiver) =
+            mpsc::channel::<oneshot::Sender<Status>>(1);
+
+        let worker = Self {
+            http_address,
+            status_request_sender,
+            shutdown_sender,
+        };
+        let chan = HttpToStatusChannel {
+            status_request_receiver,
+        };
+
+        (worker, chan)
+    }
+
+    // run in a spawned thread
+    pub fn run_in_a_thread(self) -> Result<std::thread::JoinHandle<()>, anyhow::Error> {
+        // copied from https://tokio.rs/tokio/topics/bridging#sending-messages
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("Failed to build tokio runtime.")?;
+
+        let thread_builder = std::thread::Builder::new().name("loki_http_worker".to_string());
+        let handle = thread_builder.spawn(move || runtime.block_on(self.run()))?;
+        Ok(handle)
+    }
+
+    async fn run(self) {
+        // The closure inside `make_service_fn` is run for each connection,
+        // creating a 'service' to handle requests for that specific connection.
+        let make_service = make_service_fn(move |_| {
+            // While the status_request_sender was moved into the make_service closure,
+            // we need to clone it here because this closure is called
+            // once for every connection.
+            //
+            // Each connection could send multiple requests, so
+            // the `Service` needs a clone to handle later requests.
+            let status_request_sender = self.status_request_sender.clone();
+
+            async move {
+                // This is the `Service` that will handle the connection.
+                // `service_fn` is a helper to convert a function that
+                // returns a Response into a `Service`.
+                Ok::<_, hyper::Error>(service_fn(move |http_request| {
+                    handle_http_request(http_request, status_request_sender.clone())
+                }))
+            }
+        });
+
+        let server = hyper::Server::bind(&self.http_address).serve(make_service);
+
+        info!("Http worker is listening on http://{}", self.http_address);
+
+        if let Err(e) = server.await {
+            error!("Http worker error: {}", e);
+            let _ = self.shutdown_sender.send(()).await;
+        }
+    }
+}
+
+async fn handle_http_request(
+    http_request: Request<Body>,
+    status_request_sender: mpsc::Sender<oneshot::Sender<Status>>,
+) -> Result<Response<Body>, hyper::http::Error> {
+    match (http_request.method(), http_request.uri().path()) {
+        // Serve some instructions at GET /status
+        (&Method::GET, "/status") => match handle_status_request(status_request_sender).await {
+            Ok(bytes) => Response::builder()
+                .status(StatusCode::OK)
+                .body(Body::from(bytes)),
+            Err(err) => {
+                error!("{:#}", err);
+                Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(Body::empty())
+            }
+        },
+
+        // Return the 404 Not Found for other routes.
+        _ => {
+            info!(
+                "Received http request with invalid (method, path) : ({}, {})",
+                http_request.method(),
+                http_request.uri().path()
+            );
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(Body::empty());
+        }
+    }
+}
+
+async fn handle_status_request(
+    status_request_sender: mpsc::Sender<oneshot::Sender<Status>>,
+) -> Result<Vec<u8>, Error> {
+    let (status_response_sender, status_response_receiver) = oneshot::channel();
+    let timeout = tokio::time::Duration::from_secs(3);
+
+    // send a request to the status worker
+    let _ = status_request_sender
+        .send_timeout(status_response_sender, timeout)
+        .await
+        .map_err(|_| format_err!("Could not send request to status worker"))?;
+
+    let status = status_response_receiver
+        .await
+        .context("Could not receive response from status worker")?;
+
+    serde_json::to_vec_pretty(&status).context("Could not serialize status to json")
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -56,6 +56,7 @@ pub mod response;
 pub mod chaos;
 pub mod compute_worker;
 pub mod data_downloader;
+pub mod http_worker;
 pub mod load_balancer;
 pub mod master_worker;
 pub mod status_worker;

--- a/server/src/master_worker.rs
+++ b/server/src/master_worker.rs
@@ -74,7 +74,7 @@ impl MasterWorker {
 
         // http worker
         let (http_worker, http_to_status_channel) =
-            HttpWorker::new(config.http_address, shutdown_sender.clone());
+            HttpWorker::new(config.http.clone(), shutdown_sender.clone());
         let _http_worker_handle = http_worker.run_in_a_thread()?;
 
         // LoadBalancer

--- a/server/src/server_config.rs
+++ b/server/src/server_config.rs
@@ -51,6 +51,10 @@ pub struct ServerConfig {
     /// zmq socket to listen for protobuf requests
     pub requests_socket: String,
 
+    /// http endpoint for healthcheck
+    #[serde(default = "default_http_address")]
+    pub http_address: std::net::SocketAddr,
+
     /// type of input data given (ntfs/gtfs)
     #[serde(default)]
     pub input_data_type: InputDataType,
@@ -97,6 +101,7 @@ impl ServerConfig {
             }),
             input_data_type: Default::default(),
             requests_socket: zmq_socket.to_string(),
+            http_address: default_http_address(),
             instance_name: instance_name.to_string(),
             default_request_params: config::RequestParams::default(),
             rabbitmq: RabbitMqParams::default(),
@@ -136,6 +141,10 @@ pub struct RabbitMqParams {
 
 pub fn default_nb_workers() -> u16 {
     1
+}
+
+pub fn default_http_address() -> std::net::SocketAddr {
+    ([127, 0, 0, 1], 3000).into()
 }
 
 pub fn default_rabbitmq_endpoint() -> String {
@@ -266,7 +275,7 @@ mod tests {
         let read_result = read_config(&path);
         assert!(
             read_config(&path).is_ok(),
-            "Error while reading config file {:?} : {:?}",
+            "Error while reading config file {:?} : {:#?}",
             &path,
             read_result
         );

--- a/server/src/status_worker.rs
+++ b/server/src/status_worker.rs
@@ -194,7 +194,7 @@ impl StatusWorker {
                         format_err!("StatusWorker : channel to receive http status requests is closed.")
                     )?;
                     let send_result = response_chan.send(self.status.clone());
-                    if let Err(_) = send_result {
+                    if send_result.is_err() {
                         error!("Error while sending status response to http worker : the receiver is closed.");
                     }
                 }

--- a/server/src/status_worker.rs
+++ b/server/src/status_worker.rs
@@ -77,15 +77,15 @@ pub struct StatusWorker {
 
 #[derive(Serialize, Clone)]
 pub struct Status {
-    base_data_info: Option<BaseDataInfo>,
-    config_info: ConfigInfo,
-    last_load_succeeded: bool, // last reload was successful
-    is_realtime_loaded: bool,  // is_realtime_loaded for the last reload
-    is_connected_to_rabbitmq: bool,
-    last_kirin_reload: Option<NaiveDateTime>,
-    last_chaos_reload: Option<NaiveDateTime>,
-    last_real_time_update: Option<NaiveDateTime>,
-    loki_version: String,
+    pub base_data_info: Option<BaseDataInfo>,
+    pub config_info: ConfigInfo,
+    pub last_load_succeeded: bool, // last reload was successful
+    pub is_realtime_loaded: bool,  // is_realtime_loaded for the last reload
+    pub is_connected_to_rabbitmq: bool,
+    pub last_kirin_reload: Option<NaiveDateTime>,
+    pub last_chaos_reload: Option<NaiveDateTime>,
+    pub last_real_time_update: Option<NaiveDateTime>,
+    pub loki_version: String,
 }
 
 #[derive(Serialize, Clone)]

--- a/server/tests/main_test.rs
+++ b/server/tests/main_test.rs
@@ -106,6 +106,9 @@ async fn run() {
     wait_until_data_loaded_after(zmq_endpoint, &start_test_datetime).await;
     wait_until_connected_to_rabbitmq(zmq_endpoint).await;
 
+    subtests::http_test::health_test(&config.http).await;
+    subtests::http_test::status_test(&config.http).await;
+
     subtests::realtime_test::remove_add_modify_base_vj_test(&config).await;
     subtests::realtime_test::remove_add_modify_new_vj_test(&config).await;
 

--- a/server/tests/subtests/http_test.rs
+++ b/server/tests/subtests/http_test.rs
@@ -27,10 +27,30 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-pub mod chaos_test;
-pub mod http_test;
-pub mod places_nearby_test;
-pub mod realtime_test;
-pub mod reload_test;
-pub mod schedule_test;
-pub mod status_metadata_test;
+use std::str::FromStr;
+
+use hyper::{StatusCode, Uri};
+pub use loki_server;
+use loki_server::server_config::HttpParams;
+
+pub async fn status_test(http_params: &HttpParams) {
+    let client = hyper::client::Client::new();
+    let address = http_params.http_address.to_string();
+    let uri_string = format!("http://{}/status", address);
+    let uri = Uri::from_str(&uri_string).unwrap();
+
+    let response = client.get(uri).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+pub async fn health_test(http_params: &HttpParams) {
+    let client = hyper::client::Client::new();
+    let address = http_params.http_address.to_string();
+    let uri_string = format!("http://{}/health", address);
+    let uri = Uri::from_str(&uri_string).unwrap();
+
+    let response = client.get(uri).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/server/tests/subtests/status_metadata_test.rs
+++ b/server/tests/subtests/status_metadata_test.rs
@@ -31,7 +31,7 @@ pub use loki_server;
 use loki_server::{navitia_proto, server_config::ServerConfig};
 
 use launch::loki::{chrono::Utc, NaiveDateTime};
-use loki_server::status_worker::{DATETIME_FORMAT, PKG_VERSION};
+use loki_server::status_worker::{DATETIME_FORMAT, LOKI_VERSION};
 
 pub async fn status_test(config: &ServerConfig) {
     let status_request = make_status_request();
@@ -43,7 +43,7 @@ pub async fn status_test(config: &ServerConfig) {
     let status = response.status.unwrap();
     assert_eq!(status.start_production_date, "20210101");
     assert_eq!(status.end_production_date, "20210103");
-    assert_eq!(status.navitia_version, Some(PKG_VERSION.to_string()));
+    assert_eq!(status.navitia_version, Some(LOKI_VERSION.to_string()));
     assert_eq!(status.loaded, Some(true));
     assert_eq!(status.nb_threads, Some(1));
     assert_eq!(status.is_connected_to_rabbitmq, Some(true));


### PR DESCRIPTION
Add an http server with : 

- a `/status` route that provides the same info as the status requests on the zmq endpoint
- a `/health` that answer with a 200 when the data is loaded, and a 404 otherwise

The endpoint is 127.0.0.1:3000 by default, and can be modified in the config file