### PR TITLE
Uniformize log

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,7 @@ jobs:
         fail-fast: false
         matrix:
                 build_type: [{name: "Release", flag: "--release"}, {name: "Debug", flag: ""}]
-                features: ["launch/vehicle_loads", ""]
+                features: ["loki_launch/vehicle_loads", ""]
 
     steps:
     - name: Set Swap Space

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,19 +1371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "launch"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "loki",
- "rstest",
- "serde",
- "serde_json",
- "thousands",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,13 +1433,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "loki_launch"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "loki",
+ "rstest",
+ "serde",
+ "serde_json",
+ "thousands",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "loki_random"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "hdrhistogram",
- "launch",
  "log",
+ "loki_launch",
  "rand",
  "rand_chacha",
  "serde",
@@ -1471,7 +1471,7 @@ dependencies = [
  "hostname",
  "hyper",
  "lapin",
- "launch",
+ "loki_launch",
  "num-traits",
  "prost",
  "prost-build",
@@ -1496,7 +1496,7 @@ name = "loki_stop_areas"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "launch",
+ "loki_launch",
  "serde",
  "structopt",
  "toml 0.5.9",

--- a/launch/Cargo.toml
+++ b/launch/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "launch"
+name = "loki_launch"
 version = "0.1.0"
 authors = ["Pascal Benchimol <pascal.benchimol@kisio.com>"]
 edition = "2021"

--- a/launch/src/logger.rs
+++ b/launch/src/logger.rs
@@ -1,4 +1,5 @@
 use loki::tracing::dispatcher::DefaultGuard;
+use std::str::FromStr;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 
 // Create a subscriber to collect all logs
@@ -10,26 +11,19 @@ pub fn init_logger() {
     // See https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html#directives
     // for more details on how to configure log filtering
     let default_level = "loki=info";
-    let rust_log =
-        std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
-    let env_filter_subscriber = EnvFilter::try_new(rust_log).unwrap_or_else(|err| {
-        eprintln!(
-            "invalid {}, falling back to level '{}' - {}",
-            EnvFilter::DEFAULT_ENV,
-            default_level,
-            err,
-        );
-        EnvFilter::new(default_level)
-    });
+    let env_filter = filter(default_level);
+
+    let ansi_color = ansi_color(false);
+
     let format = tracing_subscriber::fmt::format()
         .with_thread_ids(false) // set to true to display id of the thread emitting the log
         .with_source_location(true) // set to true to include source file and line number in log
         .with_target(false) // set to true to include module name in logs
-        .with_ansi(false) // set to false to remove color in output
+        .with_ansi(ansi_color) // set to false to remove color in output
         .compact();
     let subscriber = tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().event_format(format))
-        .with(env_filter_subscriber);
+        .with(env_filter);
     loki::tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set global tracing subscriber.");
 }
@@ -40,22 +34,15 @@ pub fn subscriber_for_tests() -> impl SubscriberExt {
     // See https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html#directives
     // for more details on how to configure log filtering
     let default_level = "loki=debug";
-    let rust_log =
-        std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
-    let env_filter_subscriber = EnvFilter::try_new(rust_log).unwrap_or_else(|err| {
-        eprintln!(
-            "invalid {}, falling back to level '{}' - {}",
-            EnvFilter::DEFAULT_ENV,
-            default_level,
-            err,
-        );
-        EnvFilter::new(default_level)
-    });
+    let env_filter = filter(default_level);
+
+    let ansi_color = ansi_color(true);
+
     let format = tracing_subscriber::fmt::format()
         .with_thread_ids(false) // set to true to display id of the thread emitting the log
         .with_source_location(true) // set to true to include source file and line number in log
         .with_target(false) // set to true to include module name in logs
-        .with_ansi(true) // set to false to remove color in output
+        .with_ansi(ansi_color) // set to false to remove color in output
         .compact();
     tracing_subscriber::registry()
         .with(
@@ -63,7 +50,7 @@ pub fn subscriber_for_tests() -> impl SubscriberExt {
                 .event_format(format)
                 .with_test_writer(),
         )
-        .with(env_filter_subscriber)
+        .with(env_filter)
 }
 
 #[must_use]
@@ -89,4 +76,23 @@ pub fn init_global_test_logger() {
     let subscriber = subscriber_for_tests();
     loki::tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set global tracing subscriber.");
+}
+
+pub fn filter(default_level: &str) -> EnvFilter {
+    let rust_log =
+        std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
+    EnvFilter::try_new(rust_log).unwrap_or_else(|err| {
+        eprintln!(
+            "invalid {}, falling back to filter '{}' - {}",
+            EnvFilter::DEFAULT_ENV,
+            default_level,
+            err,
+        );
+        EnvFilter::new(default_level)
+    })
+}
+
+pub fn ansi_color(default: bool) -> bool {
+    let ansi_color_string = std::env::var("LOKI_LOG_COLOR").unwrap_or_default();
+    bool::from_str(&ansi_color_string).unwrap_or(default)
 }

--- a/launch/src/logger.rs
+++ b/launch/src/logger.rs
@@ -6,6 +6,9 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 // Warning : this function will panic if called twice in the same program
 // https://docs.rs/tracing/latest/tracing/dispatcher/index.html
 pub fn init_logger() {
+    // This will enable all logs from loki* crates at INFO level, and deactivate all logs from other dependecies.
+    // See https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html#directives
+    // for more details on how to configure log filtering
     let default_level = "loki=info";
     let rust_log =
         std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
@@ -32,7 +35,9 @@ pub fn init_logger() {
 }
 
 pub fn subsciber_for_tests() -> impl SubscriberExt {
-    // will print logs at debug level from all loki* crates
+    // This will enable all logs from loki* crates at DEBUG level, and deactivate all logs from other dependecies.
+    // See https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html#directives
+    // for more details on how to configure log filtering
     let default_level = "loki=debug";
     let rust_log =
         std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());

--- a/launch/src/logger.rs
+++ b/launch/src/logger.rs
@@ -19,7 +19,7 @@ pub fn init_logger() {
             default_level,
             err,
         );
-        EnvFilter::new(default_level.to_string())
+        EnvFilter::new(default_level)
     });
     let format = tracing_subscriber::fmt::format()
         .with_thread_ids(false) // set to true to display id of the thread emitting the log
@@ -34,7 +34,8 @@ pub fn init_logger() {
         .expect("Failed to set global tracing subscriber.");
 }
 
-pub fn subsciber_for_tests() -> impl SubscriberExt {
+#[must_use]
+pub fn subscriber_for_tests() -> impl SubscriberExt {
     // This will enable all logs from loki* crates at DEBUG level, and deactivate all logs from other dependecies.
     // See https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html#directives
     // for more details on how to configure log filtering
@@ -48,7 +49,7 @@ pub fn subsciber_for_tests() -> impl SubscriberExt {
             default_level,
             err,
         );
-        EnvFilter::new(default_level.to_string())
+        EnvFilter::new(default_level)
     });
     let format = tracing_subscriber::fmt::format()
         .with_thread_ids(false) // set to true to display id of the thread emitting the log
@@ -73,7 +74,7 @@ pub fn subsciber_for_tests() -> impl SubscriberExt {
 // This logger support libtest's output capturing
 // https://docs.rs/tracing-subscriber/0.3.3/tracing_subscriber/fmt/struct.Layer.html#method.with_test_writer
 pub fn init_test_logger() -> DefaultGuard {
-    let subscriber = subsciber_for_tests();
+    let subscriber = subscriber_for_tests();
     loki::tracing::subscriber::set_default(subscriber)
 }
 
@@ -85,7 +86,7 @@ pub fn init_test_logger() -> DefaultGuard {
 // This logger support libtest's output capturing
 // https://docs.rs/tracing-subscriber/0.3.3/tracing_subscriber/fmt/struct.Layer.html#method.with_test_writer
 pub fn init_global_test_logger() {
-    let subscriber = subsciber_for_tests();
+    let subscriber = subscriber_for_tests();
     loki::tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set global tracing subscriber.");
 }

--- a/launch/src/logger.rs
+++ b/launch/src/logger.rs
@@ -1,4 +1,3 @@
-use crate::loki::tracing::level_filters::LevelFilter;
 use loki::tracing::dispatcher::DefaultGuard;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 
@@ -7,7 +6,7 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 // Warning : this function will panic if called twice in the same program
 // https://docs.rs/tracing/latest/tracing/dispatcher/index.html
 pub fn init_logger() {
-    let default_level = LevelFilter::INFO;
+    let default_level = "loki=info";
     let rust_log =
         std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
     let env_filter_subscriber = EnvFilter::try_new(rust_log).unwrap_or_else(|err| {

--- a/launch/src/solver.rs
+++ b/launch/src/solver.rs
@@ -176,6 +176,7 @@ where
         "arrivals {:#?}",
         request_input.arrivals_stop_point_and_fallback_duration
     );
+    debug!("datetime : {}", request_input.datetime);
     debug!("datetime_represents : {}", datetime_represent);
     debug!("comparator type : {}", comparator_type);
     debug!(

--- a/launch/tests/loads_test.rs
+++ b/launch/tests/loads_test.rs
@@ -36,11 +36,11 @@
 
 use crate::utils::{build_and_solve, Config};
 use anyhow::Error;
-use launch::{config::ComparatorType, read::read_loads_data};
 use loki::{
     models::{base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs},
     PositiveDuration,
 };
+use loki_launch::{config::ComparatorType, read::read_loads_data};
 use utils::model_builder::ModelBuilder;
 mod utils;
 
@@ -81,7 +81,7 @@ fn test_loads_matin() -> Result<(), Error> {
     // The `soir` trip arrives later and has a high load, and thus should
     //  not be present.
 
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let base_model = create_model();
 
@@ -114,7 +114,7 @@ fn test_loads_midi() -> Result<(), Error> {
     // We should obtain only one journey with the `midi` trip.
     // Indeed, `matin` cannot be boarded, and `soir` arrives
     // later than `midi` with a higher load
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let base_model = create_model();
 
@@ -141,7 +141,7 @@ fn test_without_loads_matin() -> Result<(), Error> {
     // We do NOT use the loads as criteria.
     // We should obtain only one journey with the `matin` trip.
     // Indeed, `midi` and `soir` arrives later than `matin`.
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let base_model = create_model();
 

--- a/launch/tests/local_zone_test.rs
+++ b/launch/tests/local_zone_test.rs
@@ -36,14 +36,14 @@
 
 mod utils;
 use anyhow::Error;
-use launch::loki::models::{real_time_model::RealTimeModel, ModelRefs};
 use loki::{models::base_model::BaseModel, DataTrait, PositiveDuration};
+use loki_launch::loki::models::{real_time_model::RealTimeModel, ModelRefs};
 
 use utils::{build_and_solve, model_builder::ModelBuilder, Config};
 
 #[test]
 fn test_local_zone_routing() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2022-01-01", "2022-01-02")
         .vj("LocalZone", |vj_builder| {
@@ -91,7 +91,7 @@ fn test_local_zone_routing() -> Result<(), Error> {
 
 #[test]
 fn test_local_zone_timetable() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2022-01-01", "2022-01-02")
         .vj("LocalZone", |vj_builder| {
@@ -113,7 +113,7 @@ fn test_local_zone_timetable() -> Result<(), Error> {
 
     // Since there are 3 different local zone, 3 missions must be created
     let expected_mission_nb = 3;
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
     assert_eq!(data.nb_of_missions(), expected_mission_nb);
 
     Ok(())
@@ -121,7 +121,7 @@ fn test_local_zone_timetable() -> Result<(), Error> {
 
 #[test]
 fn test_local_zone_routing_multiple_vj() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2022-01-01", "2022-01-02")
         .vj("LocalZone", |vj_builder| {
@@ -183,7 +183,7 @@ fn test_local_zone_routing_multiple_vj() -> Result<(), Error> {
 
 #[test]
 fn test_local_zone_routing_one_local_zone() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2022-01-01", "2022-01-02")
         .vj("LocalZone", |vj_builder| {

--- a/launch/tests/next_schedule_test.rs
+++ b/launch/tests/next_schedule_test.rs
@@ -38,7 +38,6 @@ mod utils;
 use anyhow::{format_err, Error};
 
 use crate::utils::model_builder::AsDateTime;
-use launch::solver::Solver;
 use loki::{
     chrono::Duration,
     models::{base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs},
@@ -46,6 +45,7 @@ use loki::{
     schedule::{ScheduleOn, ScheduleRequestInput, ScheduleResponse},
     NaiveDateTime, PositiveDuration, RealTimeLevel, TransitData,
 };
+use loki_launch::solver::Solver;
 use rstest::{fixture, rstest};
 use utils::model_builder::ModelBuilder;
 
@@ -112,7 +112,7 @@ pub fn fixture_model() -> BaseModel {
 
 #[rstest]
 fn test_no_pickup_dropoff(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // This part checks that the pickup / drop_off fields of a StopTime are taken into account by
     // next_schedule functions
@@ -150,7 +150,7 @@ fn test_no_pickup_dropoff(fixture_model: BaseModel) -> Result<(), Error> {
 
 #[rstest]
 fn test_at_first_and_last_stops(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // This test ensure that no departure is possible on terminus stop_point
     // and no arrival is possible on departure stop_point
@@ -186,7 +186,7 @@ fn test_at_first_and_last_stops(fixture_model: BaseModel) -> Result<(), Error> {
 
 #[rstest]
 fn test_range_datetime(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // This part test if until_datetime (ie from_datetime + duration)
     // is working properly
@@ -238,7 +238,7 @@ fn test_range_datetime(fixture_model: BaseModel) -> Result<(), Error> {
 
 #[rstest]
 fn test_invalid_range_datetime(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // This code test multiple from/until_datetime combination
     // some datetime could be outside calendar range
@@ -319,7 +319,7 @@ fn test_invalid_range_datetime(fixture_model: BaseModel) -> Result<(), Error> {
 
 #[rstest]
 fn test_past_midnight_vehicle(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // This code checks that vehicle valid on day : from_date - 2 & from_date -1
     // and with a next_schedule (departure/arrival) after from_datetime are returned as expected
@@ -369,7 +369,7 @@ fn test_past_midnight_vehicle(fixture_model: BaseModel) -> Result<(), Error> {
 
 #[rstest]
 fn test_on_route(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // In this test we expect to receive all departure of all stop_points of route R1
     // after a certain datetime (we test multiple datetime)
@@ -421,7 +421,7 @@ fn test_on_route(fixture_model: BaseModel) -> Result<(), Error> {
 
 #[rstest]
 fn test_on_network(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // In this test we expect to receive all departure of all stop_points of network N1
     // after a certain datetime
@@ -472,7 +472,7 @@ fn test_on_network(fixture_model: BaseModel) -> Result<(), Error> {
 
 #[rstest]
 fn test_forbidden_filter(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // In this test we call next_departures/next_arrivals with a forbidden filter
 
@@ -569,7 +569,7 @@ fn build_and_solve_schedule(
 
     let real_time_model = RealTimeModel::new();
     let model_refs = ModelRefs::new(base_model, &real_time_model);
-    let data: TransitData = launch::read::build_transit_data(model_refs.base);
+    let data: TransitData = loki_launch::read::build_transit_data(model_refs.base);
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 

--- a/launch/tests/pickup_dropoff_test.rs
+++ b/launch/tests/pickup_dropoff_test.rs
@@ -36,11 +36,11 @@
 
 mod utils;
 use anyhow::Error;
-use launch::{
+use loki::{models::base_model::BaseModel, PositiveDuration};
+use loki_launch::{
     config::ComparatorType,
     loki::models::{real_time_model::RealTimeModel, ModelRefs},
 };
-use loki::{models::base_model::BaseModel, PositiveDuration};
 use rstest::rstest;
 use utils::{build_and_solve, model_builder::ModelBuilder, Config};
 
@@ -48,7 +48,7 @@ use utils::{build_and_solve, model_builder::ModelBuilder, Config};
 #[case(ComparatorType::Loads)]
 #[case(ComparatorType::Basic)]
 fn test_forbidden_pickup(#[case] comparator_type: ComparatorType) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
@@ -85,7 +85,7 @@ fn test_forbidden_pickup(#[case] comparator_type: ComparatorType) -> Result<(), 
 #[case(ComparatorType::Loads)]
 #[case(ComparatorType::Basic)]
 fn test_forbidden_dropoff(#[case] comparator_type: ComparatorType) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
@@ -122,7 +122,7 @@ fn test_forbidden_dropoff(#[case] comparator_type: ComparatorType) -> Result<(),
 #[case(ComparatorType::Loads)]
 #[case(ComparatorType::Basic)]
 fn test_skipped_stop(#[case] comparator_type: ComparatorType) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {

--- a/launch/tests/places_nearby_tests.rs
+++ b/launch/tests/places_nearby_tests.rs
@@ -117,7 +117,7 @@ pub fn fixture_model() -> BaseModel {
 
 #[rstest]
 fn places_nearby_error_handling(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let real_time_model = RealTimeModel::new();
     let model_refs = ModelRefs::new(&fixture_model, &real_time_model);
@@ -184,7 +184,7 @@ fn places_nearby_error_handling(fixture_model: BaseModel) -> Result<(), Error> {
 
 #[rstest]
 fn places_nearby_coord(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     places_nearby_impl_test(
         &fixture_model,
@@ -212,7 +212,7 @@ fn places_nearby_coord(fixture_model: BaseModel) -> Result<(), Error> {
 
 #[rstest]
 fn places_nearby_stop_point(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     places_nearby_impl_test(
         &fixture_model,
@@ -233,7 +233,7 @@ fn places_nearby_stop_point(fixture_model: BaseModel) -> Result<(), Error> {
 
 #[rstest]
 fn places_nearby_stop_area(fixture_model: BaseModel) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     places_nearby_impl_test(
         &fixture_model,

--- a/launch/tests/routing_with_filters_test.rs
+++ b/launch/tests/routing_with_filters_test.rs
@@ -36,7 +36,7 @@
 
 mod utils;
 use anyhow::Error;
-use launch::config::ComparatorType;
+use loki_launch::config::ComparatorType;
 
 use loki::{
     models::{base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs},
@@ -139,7 +139,7 @@ fn test_no_filter(
     #[case] comparator_type: ComparatorType,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let config = Config::new("2020-01-01T09:59:00", "A", "J");
     let config = Config {
@@ -174,7 +174,7 @@ fn test_filter_forbidden_stop_point(
     #[case] comparator_type: ComparatorType,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // With Filter : stop_point:C is forbidden
     let config = Config::new("2020-01-01T09:59:00", "A", "J");
@@ -212,7 +212,7 @@ fn test_filter_allowed_stop_point(
     #[case] comparator_type: ComparatorType,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // With Filter : stop_point:C is forbidden
     let config = Config::new("2020-01-01T09:59:00", "A", "J");
@@ -257,7 +257,7 @@ fn test_filter_forbidden_route(
     #[case] comparator_type: ComparatorType,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // With Filter : stop_point:C is forbidden
     let config = Config::new("2020-01-01T09:59:00", "A", "J");
@@ -294,7 +294,7 @@ fn test_filter_allowed_route(
     #[case] comparator_type: ComparatorType,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // With Filter : stop_point:C is forbidden
     let config = Config::new("2020-01-01T09:59:00", "A", "J");
@@ -331,7 +331,7 @@ fn test_filter_wheelchair_no_solution(
     #[case] comparator_type: ComparatorType,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // With Filter : wheelchair_accessible = true,
     let config = Config::new("2020-01-01T09:59:00", "E", "G");
@@ -369,7 +369,7 @@ fn test_filter_bike(
     #[case] comparator_type: ComparatorType,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // With Filter : wheelchair_accessible = true,
     let config = Config::new("2020-01-01T09:59:00", "A", "C");
@@ -412,7 +412,7 @@ fn test_filter_accessibility_with_transfer(
     #[case] comparator_type: ComparatorType,
     fixture_model: BaseModel,
 ) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // With Filter : wheelchair_accessible = true,
     let config = Config::new("2020-01-01T09:59:00", "A", "G");

--- a/launch/tests/simple_routing_test.rs
+++ b/launch/tests/simple_routing_test.rs
@@ -36,12 +36,12 @@
 
 mod utils;
 use anyhow::Error;
-use launch::{
+use loki::{models::base_model::BaseModel, PositiveDuration, RealTimeLevel};
+use loki_launch::{
     config::ComparatorType,
     datetime::DateTimeRepresent,
     loki::models::{real_time_model::RealTimeModel, ModelRefs},
 };
-use loki::{models::base_model::BaseModel, PositiveDuration, RealTimeLevel};
 use rstest::rstest;
 use utils::{
     build_and_solve, from_to_stop_point_names,
@@ -53,7 +53,7 @@ use utils::{
 #[case(ComparatorType::Loads)]
 #[case(ComparatorType::Basic)]
 fn test_simple_routing(#[case] comparator_type: ComparatorType) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
@@ -109,7 +109,7 @@ fn test_simple_routing(#[case] comparator_type: ComparatorType) -> Result<(), Er
 #[case(ComparatorType::Loads)]
 #[case(ComparatorType::Basic)]
 fn test_routing_with_transfers(#[case] comparator_type: ComparatorType) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
@@ -207,7 +207,7 @@ fn test_routing_with_transfers(#[case] comparator_type: ComparatorType) -> Resul
 #[case(ComparatorType::Loads)]
 #[case(ComparatorType::Basic)]
 fn test_routing_backward(#[case] comparator_type: ComparatorType) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
@@ -310,7 +310,7 @@ fn test_routing_backward(#[case] comparator_type: ComparatorType) -> Result<(), 
 #[case(ComparatorType::Loads)]
 #[case(ComparatorType::Basic)]
 fn test_second_pass_forward(#[case] comparator_type: ComparatorType) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
@@ -384,7 +384,7 @@ fn test_second_pass_forward(#[case] comparator_type: ComparatorType) -> Result<(
 #[case(ComparatorType::Loads)]
 #[case(ComparatorType::Basic)]
 fn test_second_pass_backward(#[case] comparator_type: ComparatorType) -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("toto", |vj_builder| {
             vj_builder

--- a/launch/tests/stay_in_test.rs
+++ b/launch/tests/stay_in_test.rs
@@ -37,7 +37,7 @@
 mod utils;
 
 use anyhow::Error;
-use launch::config::launch_params::default_transfer_duration;
+use loki_launch::config::launch_params::default_transfer_duration;
 
 use loki::{
     chrono::NaiveDate,
@@ -123,7 +123,7 @@ fn is_backward_stay_in(
 
 #[test]
 fn simple_stay_in() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // We set only one valid date in calendar for simplicity
     let model = ModelBuilder::new("2020-01-01", "2020-01-01")
@@ -147,7 +147,7 @@ fn simple_stay_in() -> Result<(), Error> {
         BaseModel::from_transit_model(model, loki::LoadsData::empty(), default_transfer_duration())
             .unwrap();
 
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
 
     {
         // this assert test if we have a trip to stay_in after trip { vj 'first' on date 2020-01-01 }
@@ -184,7 +184,7 @@ fn simple_stay_in() -> Result<(), Error> {
 
 #[test]
 fn multiple_stay() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // We set only one valid date in calendar for simplicity
     let model = ModelBuilder::new("2020-01-01", "2020-01-01")
@@ -215,7 +215,7 @@ fn multiple_stay() -> Result<(), Error> {
         BaseModel::from_transit_model(model, loki::LoadsData::empty(), default_transfer_duration())
             .unwrap();
 
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
 
     {
         // this assert test if we have a trip to stay_in after trip { vj 'first' on date 2020-01-01 }
@@ -255,7 +255,7 @@ fn multiple_stay() -> Result<(), Error> {
 
 #[test]
 fn stay_in_with_wrong_stoptimes() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // We set only one valid date in calendar for simplicity
     let model = ModelBuilder::new("2020-01-01", "2020-01-01")
@@ -279,7 +279,7 @@ fn stay_in_with_wrong_stoptimes() -> Result<(), Error> {
         BaseModel::from_transit_model(model, loki::LoadsData::empty(), default_transfer_duration())
             .unwrap();
 
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
 
     // this assert test if we have a trip to stay_in after trip { vj 'first' on date 2020-01-01 }
     // we should find no nxt_trip stay_in
@@ -296,7 +296,7 @@ fn stay_in_with_wrong_stoptimes() -> Result<(), Error> {
 
 #[test]
 fn multiple_stay_in_with_wrong_stoptimes() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // We set only one valid date in calendar for simplicity
     let model = ModelBuilder::new("2020-01-01", "2020-01-01")
@@ -327,7 +327,7 @@ fn multiple_stay_in_with_wrong_stoptimes() -> Result<(), Error> {
         BaseModel::from_transit_model(model, loki::LoadsData::empty(), default_transfer_duration())
             .unwrap();
 
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
 
     // this assert test if we have a trip to stay_in after trip { vj 'first' on date 2020-01-01 }
     // we should find no next_trip stay_in
@@ -355,7 +355,7 @@ fn multiple_stay_in_with_wrong_stoptimes() -> Result<(), Error> {
 
 #[test]
 fn chain_multiple_stay_in() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // We set only one valid date in calendar for simplicity
     let model = ModelBuilder::new("2020-01-01", "2020-01-01")
@@ -386,7 +386,7 @@ fn chain_multiple_stay_in() -> Result<(), Error> {
         BaseModel::from_transit_model(model, loki::LoadsData::empty(), default_transfer_duration())
             .unwrap();
 
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
 
     {
         // this assert test if we have a trip to stay_in after trip { vj 'first' on date 2020-01-01 }
@@ -435,7 +435,7 @@ fn chain_multiple_stay_in() -> Result<(), Error> {
 
 #[test]
 fn stay_in_with_local_zone() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // We set only one valid date in calendar for simplicity
     let model = ModelBuilder::new("2020-01-01", "2020-01-01")
@@ -466,7 +466,7 @@ fn stay_in_with_local_zone() -> Result<(), Error> {
         BaseModel::from_transit_model(model, loki::LoadsData::empty(), default_transfer_duration())
             .unwrap();
 
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
 
     {
         assert!(is_forward_stay_in("first", None, &data, &base_model));
@@ -489,7 +489,7 @@ fn stay_in_with_local_zone() -> Result<(), Error> {
 
 #[test]
 fn different_validity_day_stay_in() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // We set only one valid date in calendar for simplicity
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
@@ -521,7 +521,7 @@ fn different_validity_day_stay_in() -> Result<(), Error> {
         BaseModel::from_transit_model(model, loki::LoadsData::empty(), default_transfer_duration())
             .unwrap();
 
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
 
     // this assert test if we have a trip to stay_in after trip { vj 'first' on date 2020-01-01 }
     // we should find no Trip because vj 'second' is valid on a different day ie '2020-01-02"
@@ -534,7 +534,7 @@ fn different_validity_day_stay_in() -> Result<(), Error> {
 
 #[test]
 fn multiple_day_stay_in() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // We set 10 days of validity in the calendar
     let model = ModelBuilder::new("2020-01-01", "2020-01-10")
@@ -558,7 +558,7 @@ fn multiple_day_stay_in() -> Result<(), Error> {
         BaseModel::from_transit_model(model, loki::LoadsData::empty(), default_transfer_duration())
             .unwrap();
 
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
 
     let vehicle_journey_idx = base_model.vehicle_journey_idx("first").unwrap();
     let vehicle_journey_first = base_model.vehicle_journey(vehicle_journey_idx);
@@ -594,7 +594,7 @@ fn multiple_day_stay_in() -> Result<(), Error> {
 
 #[test]
 fn past_midnight_on_same_valid_day_stay_in() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-01")
         .vj("first", |vj_builder| {
@@ -617,7 +617,7 @@ fn past_midnight_on_same_valid_day_stay_in() -> Result<(), Error> {
         BaseModel::from_transit_model(model, loki::LoadsData::empty(), default_transfer_duration())
             .unwrap();
 
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
 
     assert!(is_forward_stay_in(
         "first",
@@ -638,7 +638,7 @@ fn past_midnight_on_same_valid_day_stay_in() -> Result<(), Error> {
 
 #[test]
 fn past_midnight_on_different_valid_day_stay_in() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-2")
         .calendar_mut("c1", |c| {
@@ -669,7 +669,7 @@ fn past_midnight_on_different_valid_day_stay_in() -> Result<(), Error> {
         BaseModel::from_transit_model(model, loki::LoadsData::empty(), default_transfer_duration())
             .unwrap();
 
-    let data = launch::read::build_transit_data(&base_model);
+    let data = loki_launch::read::build_transit_data(&base_model);
 
     // a stay-in may happens only between trips with the same reference date
     // so even if the stop_times would allow to stay-in from (vj 'first' on 2020-01-01) to (vj 'second' on 2020-01-02)

--- a/launch/tests/timezone_test.rs
+++ b/launch/tests/timezone_test.rs
@@ -49,7 +49,7 @@ use utils::{
 
 #[test]
 fn test_daylight_saving_time_switch() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // There is a daylight saving time switch in Europe/paris on 2020-10-25 :
     // - on 2020-10-24, "10:00:00" in Paris means "08:00:00" UTC
@@ -105,7 +105,7 @@ fn test_daylight_saving_time_switch() -> Result<(), Error> {
 
 #[test]
 fn test_trip_over_daylight_saving_time_switch() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // There is a daylight saving time switch in Europe/paris on 2020-10-25 at 02:00:00
     let model = ModelBuilder::new("2020-10-23", "2020-10-30")
@@ -212,7 +212,7 @@ fn test_trip_over_daylight_saving_time_switch() -> Result<(), Error> {
 
 #[test]
 fn test_paris_london() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // There is a daylight saving time switch in Europe/Paris AND Europe/London on 2020-10-25 at 02:00:00
     let model = ModelBuilder::new("2020-10-01", "2020-10-30")
@@ -304,7 +304,7 @@ fn test_paris_london() -> Result<(), Error> {
 
 #[test]
 fn test_paris_new_york() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     // There is a daylight saving time switch in Europe/Paris  on 2020-10-25 at 02:00:00
     // But there is no switch in America/NewYork

--- a/launch/tests/update_data_test.rs
+++ b/launch/tests/update_data_test.rs
@@ -37,7 +37,7 @@
 mod utils;
 
 use anyhow::Error;
-use launch::solver::Solver;
+use loki_launch::solver::Solver;
 
 use loki::{
     chrono::NaiveDate,
@@ -58,7 +58,7 @@ use utils::{
 
 #[test]
 fn remove_vj() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("first", |vj_builder| {
@@ -88,7 +88,7 @@ fn remove_vj() -> Result<(), Error> {
     let real_time_model = RealTimeModel::new();
     let model_refs = ModelRefs::new(&base_model, &real_time_model);
 
-    let mut data = launch::read::build_transit_data(&base_model);
+    let mut data = loki_launch::read::build_transit_data(&base_model);
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 
@@ -169,7 +169,7 @@ fn remove_vj() -> Result<(), Error> {
 
 #[test]
 fn remove_successive_vj() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("first", |vj_builder| {
@@ -204,7 +204,7 @@ fn remove_successive_vj() -> Result<(), Error> {
     let real_time_model = RealTimeModel::new();
     let model_refs = ModelRefs::new(&base_model, &real_time_model);
 
-    let mut data = launch::read::build_transit_data(&base_model);
+    let mut data = loki_launch::read::build_transit_data(&base_model);
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 
@@ -308,7 +308,7 @@ fn remove_successive_vj() -> Result<(), Error> {
 
 #[test]
 fn remove_middle_vj() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("first", |vj_builder| {
@@ -342,7 +342,7 @@ fn remove_middle_vj() -> Result<(), Error> {
     let real_time_model = RealTimeModel::new();
     let model_refs = ModelRefs::new(&base_model, &real_time_model);
 
-    let mut data = launch::read::build_transit_data(&base_model);
+    let mut data = loki_launch::read::build_transit_data(&base_model);
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 
@@ -422,7 +422,7 @@ fn remove_middle_vj() -> Result<(), Error> {
 
 #[test]
 fn modify_vj() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("first", |vj_builder| {
@@ -446,7 +446,7 @@ fn modify_vj() -> Result<(), Error> {
     let config = Config::new("2020-01-01T09:50:00", "A", "C");
     let request_input = utils::make_request_from_config(&config);
 
-    let mut data = launch::read::build_transit_data(&base_model);
+    let mut data = loki_launch::read::build_transit_data(&base_model);
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 
@@ -551,7 +551,7 @@ fn modify_vj() -> Result<(), Error> {
 
 #[test]
 fn modify_vj_with_local_zone() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("first", |vj_builder| {
@@ -578,7 +578,7 @@ fn modify_vj_with_local_zone() -> Result<(), Error> {
 
     let request_input = utils::make_request_from_config(&config);
 
-    let mut data = launch::read::build_transit_data(&base_model);
+    let mut data = loki_launch::read::build_transit_data(&base_model);
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 
@@ -741,7 +741,7 @@ fn modify_vj_with_local_zone() -> Result<(), Error> {
 
 #[test]
 fn remove_vj_with_local_zone() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-03")
         .vj("first", |vj_builder| {
@@ -773,7 +773,7 @@ fn remove_vj_with_local_zone() -> Result<(), Error> {
 
     let request_input = utils::make_request_from_config(&config);
 
-    let mut data = launch::read::build_transit_data(&base_model);
+    let mut data = loki_launch::read::build_transit_data(&base_model);
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 
@@ -897,7 +897,7 @@ fn remove_vj_with_local_zone() -> Result<(), Error> {
 
 #[test]
 fn insert_invalid_vj() -> Result<(), Error> {
-    let _log_guard = launch::logger::init_test_logger();
+    let _log_guard = loki_launch::logger::init_test_logger();
 
     let model = ModelBuilder::new("2020-01-01", "2020-01-02")
         .vj("first", |vj_builder| {
@@ -920,7 +920,7 @@ fn insert_invalid_vj() -> Result<(), Error> {
     let mut real_time_model = RealTimeModel::new();
     let _model_refs = ModelRefs::new(&base_model, &real_time_model);
 
-    let mut data = launch::read::build_transit_data(&base_model);
+    let mut data = loki_launch::read::build_transit_data(&base_model);
 
     // insert a vehicle with a date outside of the calendar of the data
     {

--- a/launch/tests/utils/mod.rs
+++ b/launch/tests/utils/mod.rs
@@ -38,18 +38,18 @@ pub mod disruption_builder;
 pub mod model_builder;
 
 use anyhow::{format_err, Error};
-use launch::{
-    config,
-    config::launch_params::default_transfer_duration,
-    datetime::DateTimeRepresent,
-    loki::{response, response::VehicleSection, RequestInput},
-    solver::Solver,
-};
 use loki::{
     chrono::TimeZone,
     filters::{parse_filter, Filters},
     models::ModelRefs,
     RealTimeLevel,
+};
+use loki_launch::{
+    config,
+    config::launch_params::default_transfer_duration,
+    datetime::DateTimeRepresent,
+    loki::{response, response::VehicleSection, RequestInput},
+    solver::Solver,
 };
 
 use loki::{chrono_tz, tracing::debug};
@@ -142,7 +142,7 @@ pub fn build_and_solve(
     config: &Config,
 ) -> Result<Vec<response::Response>, Error> {
     use loki::DataTrait;
-    let data: TransitData = launch::read::build_transit_data(model.base);
+    let data: TransitData = loki_launch::read::build_transit_data(model.base);
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 

--- a/random/Cargo.toml
+++ b/random/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-launch = { path = "../launch"}
+loki_launch = { path = "../launch"}
 structopt = "0.3"
 serde = "1.0"
 toml = "0.5"

--- a/random/src/main.rs
+++ b/random/src/main.rs
@@ -1,4 +1,5 @@
-use launch::{
+use loki::{tracing::debug, DataTrait};
+use loki_launch::{
     config,
     loki::{
         self,
@@ -7,7 +8,6 @@ use launch::{
     solver::Solver,
     timer,
 };
-use loki::{tracing::debug, DataTrait};
 
 use std::{
     convert::TryFrom,
@@ -21,12 +21,12 @@ use rand::prelude::{IteratorRandom, SeedableRng};
 
 use anyhow::{Context, Error};
 
-use launch::datetime::DateTimeRepresent;
+use loki_launch::datetime::DateTimeRepresent;
 use serde::{Deserialize, Serialize};
 use structopt::StructOpt;
 
 fn main() {
-    launch::logger::init_logger();
+    loki_launch::logger::init_logger();
     if let Err(err) = run() {
         eprintln!("{:?}", err);
         std::process::exit(1);
@@ -101,7 +101,7 @@ pub fn read_config(config_file_path: &Path) -> Result<Config, Error> {
 }
 
 pub fn launch(config: &Config) -> Result<(), Error> {
-    let (data, base_model) = launch::read(&config.launch_params)?;
+    let (data, base_model) = loki_launch::read(&config.launch_params)?;
 
     let real_time_model = RealTimeModel::new();
     let model_refs = ModelRefs::new(&base_model, &real_time_model);
@@ -109,7 +109,7 @@ pub fn launch(config: &Config) -> Result<(), Error> {
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 
     let departure_datetime = match &config.departure_datetime {
-        Some(string_datetime) => launch::datetime::parse_datetime(string_datetime)?,
+        Some(string_datetime) => loki_launch::datetime::parse_datetime(string_datetime)?,
         None => {
             let naive_date = data.calendar().first_date();
             naive_date.and_hms(8, 0, 0)
@@ -131,7 +131,7 @@ pub fn launch(config: &Config) -> Result<(), Error> {
         let start_stop_area_uri = base_model.stop_area_id(start_stop_idx);
         let end_stop_area_uri = base_model.stop_area_id(end_stop_idx);
 
-        let request_input = launch::stop_areas::make_query_stop_areas(
+        let request_input = loki_launch::stop_areas::make_query_stop_areas(
             &base_model,
             &departure_datetime,
             start_stop_area_uri,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,7 +30,7 @@ lapin = "2.0"
 # Object Storage library (S3, Minio, ..)
 rust-s3 = "0.32"
 
-launch = { path = "../launch"}
+loki_launch = { path = "../launch"}
 structopt = "0.3"
 anyhow = "1"
 thiserror = "1"

--- a/server/src/chaos/model_v2.rs
+++ b/server/src/chaos/model_v2.rs
@@ -48,7 +48,7 @@ use crate::{
 };
 use anyhow::Error;
 use diesel::prelude::*;
-use launch::loki::{
+use loki_launch::loki::{
     chrono::{NaiveDate, NaiveTime},
     NaiveDateTime,
 };

--- a/server/src/chaos/models.rs
+++ b/server/src/chaos/models.rs
@@ -45,7 +45,7 @@ use diesel::{
     prelude::*,
     sql_types::{Bit, Date, Int4, Int8, Nullable, Text, Time, Timestamp, Uuid},
 };
-use launch::loki::{
+use loki_launch::loki::{
     chrono::{NaiveDate, NaiveTime, Timelike},
     models::real_time_disruption::chaos_disruption::BlockedStopArea,
     tracing::error,

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -41,7 +41,7 @@ use crate::{
     zmq_worker::{RequestMessage, ResponseMessage},
 };
 use anyhow::{format_err, Context, Error};
-use launch::{
+use loki_launch::{
     config::{self, ComparatorType},
     datetime::DateTimeRepresent,
     loki::{
@@ -138,7 +138,7 @@ impl ComputeWorker {
                     )
                 })?;
 
-            debug!("Worker {} sent his response.", self.worker_id.id);
+            trace!("Worker {} sent his response.", self.worker_id.id);
         }
     }
 
@@ -151,9 +151,11 @@ impl ComputeWorker {
         let requested_api = proto_request.requested_api();
 
         let start_request_time = SystemTime::now();
-        debug!(
+        trace!(
             "Worker {} received request on api {:?} with id '{}'",
-            self.worker_id.id, requested_api, request_id
+            self.worker_id.id,
+            requested_api,
+            request_id
         );
 
         let result = match requested_api {
@@ -477,11 +479,6 @@ fn solve(
     })?;
     let departure_datetime = loki::NaiveDateTime::from_timestamp(departure_timestamp_i64, 0);
 
-    debug!(
-        "Requested timestamp {}, datetime {}",
-        departure_timestamp_u64, departure_datetime
-    );
-
     let max_journey_duration = u32::try_from(journey_request.max_duration)
         .map(|duration| PositiveDuration::from_hms(0, 0, duration))
         .unwrap_or_else(|_| {
@@ -568,7 +565,6 @@ fn solve(
         true => DateTimeRepresent::Departure,
         false => DateTimeRepresent::Arrival,
     };
-    trace!("{:#?}", request_input);
 
     let responses = solver.solve_journey_request(
         data,

--- a/server/src/data_worker.rs
+++ b/server/src/data_worker.rs
@@ -64,7 +64,7 @@ use lapin::{
 use std::{io::Cursor, ops::Deref, sync::RwLockReadGuard, time::SystemTime};
 
 use futures::StreamExt;
-use launch::{
+use loki_launch::{
     loki::{
         chrono::Utc,
         chrono_tz,
@@ -91,7 +91,7 @@ use crate::{
     data_downloader::DataDownloader, handle_chaos_message::handle_chaos_protobuf,
     server_config::DataSourceParams,
 };
-use launch::config::launch_params::LocalFileParams;
+use loki_launch::config::launch_params::LocalFileParams;
 use tokio::{runtime::Builder, sync::mpsc, time::Duration};
 
 pub struct DataWorker {
@@ -334,7 +334,7 @@ impl DataWorker {
             DataSource::S3(data_downloader) => {
                 let bytes_result = data_downloader.download_data().await;
                 match bytes_result {
-                    Ok(bytes) => launch::read::read_model_from_zip_reader(
+                    Ok(bytes) => loki_launch::read::read_model_from_zip_reader(
                         Cursor::new(bytes),
                         None,
                         "S3",
@@ -344,7 +344,7 @@ impl DataWorker {
                     Err(err) => Err(err),
                 }
             }
-            DataSource::Local(local_files) => launch::read::read_model(
+            DataSource::Local(local_files) => loki_launch::read::read_model(
                 local_files,
                 config.input_data_type.clone(),
                 config.default_transfer_duration,
@@ -363,7 +363,7 @@ impl DataWorker {
         let updater = move |data_and_models: &mut DataAndModels| {
             info!("Model loaded");
             info!("Starting to build data");
-            let new_data = launch::read::build_transit_data(&new_base_model);
+            let new_data = loki_launch::read::build_transit_data(&new_base_model);
             info!("Data loaded");
             let new_real_time_model = RealTimeModel::new();
 

--- a/server/src/handle_chaos_message.rs
+++ b/server/src/handle_chaos_message.rs
@@ -36,7 +36,7 @@
 
 use crate::chaos_proto;
 use anyhow::{bail, format_err, Context, Error};
-use launch::loki::{
+use loki_launch::loki::{
     chrono::NaiveTime,
     models::{
         base_model::{

--- a/server/src/handle_kirin_message.rs
+++ b/server/src/handle_kirin_message.rs
@@ -35,7 +35,7 @@
 // www.navitia.io
 
 use anyhow::{bail, format_err, Context, Error};
-use launch::loki::{
+use loki_launch::loki::{
     chrono::{Duration, NaiveDate},
     models::{
         base_model::{strip_id_prefix, BaseModel, PREFIX_ID_STOP_POINT, PREFIX_ID_VEHICLE_JOURNEY},

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -65,7 +65,7 @@ pub mod zmq_worker;
 pub mod data_worker;
 pub mod server_config;
 
-use launch::loki::tracing::{debug, info};
+use loki_launch::loki::tracing::{debug, info};
 use server_config::ServerConfig;
 
 use structopt::StructOpt;

--- a/server/src/load_balancer.rs
+++ b/server/src/load_balancer.rs
@@ -35,7 +35,7 @@
 // www.navitia.io
 
 use anyhow::{format_err, Context, Error};
-use launch::{
+use loki_launch::{
     config,
     loki::tracing::{error, info, log::trace},
 };

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -35,7 +35,7 @@
 // www.navitia.io
 
 fn main() {
-    launch::logger::init_logger();
+    loki_launch::logger::init_logger();
     if let Err(err) = loki_server::launch_server() {
         eprintln!("{:?}", err);
         std::process::exit(1);

--- a/server/src/master_worker.rs
+++ b/server/src/master_worker.rs
@@ -35,7 +35,7 @@
 // www.navitia.io
 
 use anyhow::{bail, Context, Error};
-use launch::loki::{
+use loki_launch::loki::{
     models::{base_model::BaseModel, real_time_model::RealTimeModel},
     tracing::{error, info},
     TransitData,

--- a/server/src/response.rs
+++ b/server/src/response.rs
@@ -37,7 +37,7 @@
 use crate::navitia_proto::{self};
 use std::collections::HashSet;
 
-use launch::loki::{
+use loki_launch::loki::{
     self,
     models::{
         real_time_disruption::{
@@ -67,10 +67,6 @@ use loki::{
 };
 
 use anyhow::{bail, format_err, Context, Error};
-use launch::loki::{
-    models::base_model::StopLocationIdx,
-    transit_model::objects::{Pathway, PathwayMode, StopType},
-};
 use loki::{
     chrono::Timelike,
     models::base_model::{
@@ -84,6 +80,10 @@ use loki::{
     places_nearby::PlacesNearbyIter,
     transit_data_filtered::TransitModelTime,
     transit_model::objects::{Availability, Line, Network, Route, StopArea},
+};
+use loki_launch::loki::{
+    models::base_model::StopLocationIdx,
+    transit_model::objects::{Pathway, PathwayMode, StopType},
 };
 use num_traits::cast::ToPrimitive;
 use std::convert::TryFrom;

--- a/server/src/server_config.rs
+++ b/server/src/server_config.rs
@@ -34,9 +34,9 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use launch::{config, loki::PositiveDuration};
+use loki_launch::{config, loki::PositiveDuration};
 
-use launch::config::{
+use loki_launch::config::{
     launch_params::{default_transfer_duration, LocalFileParams},
     InputDataType,
 };

--- a/server/src/status_worker.rs
+++ b/server/src/status_worker.rs
@@ -44,11 +44,11 @@ use super::navitia_proto;
 
 use anyhow::{format_err, Context, Error};
 
-use launch::{
+use loki_launch::{
     loki::{
         chrono::NaiveDate,
         chrono_tz,
-        tracing::{debug, error, info, log::warn},
+        tracing::{error, info, trace, warn},
         NaiveDateTime,
     },
     timer,
@@ -214,9 +214,10 @@ impl StatusWorker {
         let handle_request_start_time = SystemTime::now();
         let requested_api = request_message.payload.requested_api();
         let request_id = request_message.payload.request_id.unwrap_or_default();
-        debug!(
+        trace!(
             "Status worker received request on api {:?} with id '{}'",
-            requested_api, request_id
+            requested_api,
+            request_id
         );
         let response_payload = match requested_api {
             navitia_proto::Api::Status => navitia_proto::Response {

--- a/server/src/zmq_worker.rs
+++ b/server/src/zmq_worker.rs
@@ -38,7 +38,7 @@ use std::thread;
 
 use anyhow::{format_err, Context, Error};
 
-use launch::loki::{
+use loki_launch::loki::{
     chrono::Utc,
     tracing::{error, info, log::trace, warn},
     NaiveDateTime,

--- a/server/tests/main_test.rs
+++ b/server/tests/main_test.rs
@@ -47,7 +47,7 @@ use loki_server::{
 use prost::Message;
 use protobuf::Message as ProtobufMessage;
 
-use launch::loki::{chrono::Utc, tracing::info, NaiveDateTime, PositiveDuration};
+use loki_launch::loki::{chrono::Utc, tracing::info, NaiveDateTime, PositiveDuration};
 use shiplift::builder::{BuildOptions, PullOptionsBuilder, RmContainerOptionsBuilder};
 use tracing::debug;
 
@@ -55,7 +55,7 @@ mod subtests;
 
 #[test]
 fn main() {
-    launch::logger::init_global_test_logger();
+    loki_launch::logger::init_global_test_logger();
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/server/tests/subtests/chaos_test.rs
+++ b/server/tests/subtests/chaos_test.rs
@@ -32,7 +32,7 @@ use loki_server::{chaos_proto, navitia_proto, server_config::ServerConfig};
 
 use chaos_proto::gtfs_realtime as gtfs_proto;
 use gtfs_proto::FeedHeader;
-use launch::loki::{
+use loki_launch::loki::{
     chrono,
     chrono::{NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc},
     models::real_time_disruption::time_periods::TimePeriod,

--- a/server/tests/subtests/realtime_test.rs
+++ b/server/tests/subtests/realtime_test.rs
@@ -32,7 +32,7 @@ use loki_server::{chaos_proto, navitia_proto, server_config::ServerConfig};
 
 use chaos_proto::gtfs_realtime as kirin_proto;
 use kirin_proto::FeedHeader;
-use launch::loki::{chrono::NaiveDate, NaiveDateTime};
+use loki_launch::loki::{chrono::NaiveDate, NaiveDateTime};
 use protobuf::{Enum, Message, MessageField};
 
 use crate::{arrival_time, first_section_vj_name};

--- a/server/tests/subtests/reload_test.rs
+++ b/server/tests/subtests/reload_test.rs
@@ -32,7 +32,7 @@ use std::path::Path;
 pub use loki_server;
 use loki_server::server_config::{DataSourceParams, ServerConfig};
 
-use launch::loki::NaiveDateTime;
+use loki_launch::loki::NaiveDateTime;
 
 use crate::reload_base_data;
 

--- a/server/tests/subtests/schedule_test.rs
+++ b/server/tests/subtests/schedule_test.rs
@@ -27,7 +27,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use launch::loki::{chrono::NaiveDate, schedule::ScheduleOn, NaiveDateTime, RealTimeLevel};
+use loki_launch::loki::{chrono::NaiveDate, schedule::ScheduleOn, NaiveDateTime, RealTimeLevel};
 use loki_server::{navitia_proto, server_config::ServerConfig};
 
 pub async fn simple_next_departure_test(config: &ServerConfig) {

--- a/server/tests/subtests/status_metadata_test.rs
+++ b/server/tests/subtests/status_metadata_test.rs
@@ -30,7 +30,7 @@
 pub use loki_server;
 use loki_server::{navitia_proto, server_config::ServerConfig};
 
-use launch::loki::{chrono::Utc, NaiveDateTime};
+use loki_launch::loki::{chrono::Utc, NaiveDateTime};
 use loki_server::status_worker::{DATETIME_FORMAT, LOKI_VERSION};
 
 pub async fn status_test(config: &ServerConfig) {

--- a/stop_areas/Cargo.toml
+++ b/stop_areas/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-launch = { path = "../launch"}
+loki_launch = { path = "../launch"}
 structopt = "0.3"
 serde = "1.0"
 toml = "0.5"
@@ -16,4 +16,4 @@ anyhow = "1"
 
 [features]
 # enable the vehicle_loads feature on the loki lib
-vehicle_loads = ["launch/vehicle_loads"]
+vehicle_loads = ["loki_launch/vehicle_loads"]

--- a/stop_areas/src/lib.rs
+++ b/stop_areas/src/lib.rs
@@ -34,7 +34,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use launch::{
+use loki_launch::{
     config,
     datetime::DateTimeRepresent,
     loki::{
@@ -121,7 +121,7 @@ pub fn read_config(config_file_path: &Path) -> Result<Config, Error> {
 pub fn launch(config: Config) -> Result<(BaseModel, Vec<loki::Response>), Error> {
     use loki::DataTrait;
 
-    let (data, base_model) = launch::read(&config.launch_params)?;
+    let (data, base_model) = loki_launch::read(&config.launch_params)?;
 
     let mut solver = Solver::new(data.nb_of_stops(), data.nb_of_missions());
 
@@ -129,7 +129,7 @@ pub fn launch(config: Config) -> Result<(BaseModel, Vec<loki::Response>), Error>
     let model_refs = ModelRefs::new(&base_model, &real_time_model);
 
     let datetime = match &config.datetime {
-        Some(string_datetime) => launch::datetime::parse_datetime(string_datetime)?,
+        Some(string_datetime) => loki_launch::datetime::parse_datetime(string_datetime)?,
         None => {
             let naive_date = data.calendar().first_date();
             naive_date.and_hms(8, 0, 0)
@@ -143,7 +143,7 @@ pub fn launch(config: Config) -> Result<(BaseModel, Vec<loki::Response>), Error>
     let start_stop_area_uri = &config.start_stop_area;
     let end_stop_area_uri = &config.end_stop_area;
 
-    let request_input = launch::stop_areas::make_query_stop_areas(
+    let request_input = loki_launch::stop_areas::make_query_stop_areas(
         &base_model,
         &datetime,
         start_stop_area_uri,

--- a/stop_areas/src/main.rs
+++ b/stop_areas/src/main.rs
@@ -35,7 +35,7 @@
 // www.navitia.io
 
 fn main() {
-    launch::logger::init_logger();
+    loki_launch::logger::init_logger();
     if let Err(err) = loki_stop_areas::run() {
         eprintln!("{:?}", err);
         std::process::exit(1);


### PR DESCRIPTION
Rename sub-crate "launch" to "loki_launch" so that we can obtain all logs emanating from loki (and loki only) with 
`RUST_LOG=loki=info`
This is set as the default log filter for binaries.
For tests, the default level is set to  `RUST_LOG=loki=debug`.

To activate all logs from all dependencies, set `RUST_LOG=debug`

See https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/filter/struct.EnvFilter.html#directives for more details