### PR TITLE
Config from env vars

### DIFF
--- a/.github/workflows/dockers.yml
+++ b/.github/workflows/dockers.yml
@@ -70,6 +70,7 @@ jobs:
         docker push navitia/mc_loki
         docker push navitia/mc_jormun
         docker push navitia/mc_kraken
+        docker push navitia/loki
         docker logout
 
     - name: cleanup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shiplift",
+ "temp-env",
  "tempfile",
  "thiserror",
  "tmq",
@@ -2908,6 +2909,15 @@ dependencies = [
  "p12",
  "rustls-connector",
  "rustls-pemfile",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30d48359f77fbb6af3d7b928cc2d092e1dc90b44f397e979ef08ae15733ed65"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,6 @@ dependencies = [
  "serde",
  "serde_json",
  "shiplift",
- "structopt",
  "tempfile",
  "thiserror",
  "tmq",

--- a/build_dockers.sh
+++ b/build_dockers.sh
@@ -53,3 +53,6 @@ run docker build -f docker/jormun_dockerfile -t navitia/mc_jormun --build-arg NA
 
 # build the docker for server
 run docker build -f docker/loki_dockerfile -t navitia/mc_loki .
+
+# build the docker for server
+run docker build -f docker/loki_aws_dockerfile -t navitia/loki .

--- a/docker/loki_aws_dockerfile
+++ b/docker/loki_aws_dockerfile
@@ -1,0 +1,9 @@
+# Before building this docker,
+# you should have built navitia/mc_loki from ./loki_dockerfile
+FROM navitia/mc_loki
+
+# Loki will be configured from env variables
+CMD ["/usr/local/bin/loki_server"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=2m \
+  CMD curl -f http://${LOKI_HTTP_ADDRESS}/health || exit 1

--- a/launch/src/config/input_data_type.rs
+++ b/launch/src/config/input_data_type.rs
@@ -36,7 +36,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum InputDataType {
     Gtfs,
@@ -71,6 +71,15 @@ impl std::fmt::Display for InputDataType {
         match self {
             InputDataType::Gtfs => write!(f, "gtfs"),
             InputDataType::Ntfs => write!(f, "ntfs"),
+        }
+    }
+}
+
+impl std::fmt::Debug for InputDataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Gtfs => write!(f, "gtfs"),
+            Self::Ntfs => write!(f, "ntfs"),
         }
     }
 }

--- a/launch/src/config/input_data_type.rs
+++ b/launch/src/config/input_data_type.rs
@@ -82,6 +82,8 @@ pub struct InputDataTypeConfigError {
 
 impl std::fmt::Display for InputDataTypeConfigError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Bad input data type give : `{}`", self.input_type_name)
+        write!(f, "Bad input data type given : `{}`", self.input_type_name)
     }
 }
+
+impl std::error::Error for InputDataTypeConfigError {}

--- a/launch/src/config/launch_params.rs
+++ b/launch/src/config/launch_params.rs
@@ -36,7 +36,7 @@
 
 use std::path::PathBuf;
 
-use super::InputDataType;
+use super::{parse_env_var, read_env_var, InputDataType};
 use anyhow::Context;
 use loki::PositiveDuration;
 
@@ -90,9 +90,10 @@ impl LocalFileParams {
         let input_data_path = std::env::var("LOKI_INPUT_DATA_PATH")
             .map(PathBuf::from)
             .context("Could not read mandatory env var LOKI_INPUT_DATA_PATH")?;
-        let loads_data_path = std::env::var("LOKI_LOADS_DATA_PATH")
-            .map(|s| Some(PathBuf::from(s)))
-            .unwrap_or(None);
+
+        let loads_data_path =
+            read_env_var("LOKI_LOADS_DATA_PATH", None, |s| Some(PathBuf::from(s)));
+
         Ok(Self {
             input_data_path,
             loads_data_path,

--- a/launch/src/config/launch_params.rs
+++ b/launch/src/config/launch_params.rs
@@ -36,7 +36,7 @@
 
 use std::path::PathBuf;
 
-use super::{parse_env_var, read_env_var, InputDataType};
+use super::{read_env_var, InputDataType};
 use anyhow::Context;
 use loki::PositiveDuration;
 

--- a/launch/src/config/launch_params.rs
+++ b/launch/src/config/launch_params.rs
@@ -88,7 +88,7 @@ pub struct LocalFileParams {
 impl LocalFileParams {
     pub fn new_from_env_vars() -> Result<Self, anyhow::Error> {
         let input_data_path = std::env::var("LOKI_INPUT_DATA_PATH")
-            .map(|s| PathBuf::from(s))
+            .map(PathBuf::from)
             .context("Could not read mandatory env var LOKI_INPUT_DATA_PATH")?;
         let loads_data_path = std::env::var("LOKI_LOADS_DATA_PATH")
             .map(|s| Some(PathBuf::from(s)))

--- a/launch/src/config/request_params.rs
+++ b/launch/src/config/request_params.rs
@@ -112,3 +112,40 @@ impl Default for RequestParams {
         }
     }
 }
+
+impl RequestParams {
+    pub fn new_from_env_vars() -> Self {
+        let leg_arrival_penalty = {
+            let s = std::env::var("LOKI_LEG_ARRIVAL_PENALTY").unwrap_or_default();
+            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_leg_arrival_penalty())
+        };
+        let leg_walking_penalty = {
+            let s = std::env::var("LOKI_LEG_WALKING_PENALTY").unwrap_or_default();
+            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_leg_walking_penalty())
+        };
+        let max_nb_of_legs = {
+            let s = std::env::var("LOKI_MAX_NB_OF_LEGS").unwrap_or_default();
+            u8::from_str(&s).unwrap_or_else(|_| default_max_nb_of_legs())
+        };
+        let max_journey_duration = {
+            let s = std::env::var("LOKI_MAX_JOURNEY_DURATION").unwrap_or_default();
+            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_max_journey_duration())
+        };
+        let too_late_threshold = {
+            let s = std::env::var("LOKI_TOO_LATE_THRESHOLD").unwrap_or_default();
+            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_too_late_threshold())
+        };
+        let real_time_level = {
+            let s = std::env::var("LOKI_REAL_TIME_LEVEL").unwrap_or_default();
+            RealTimeLevel::from_str(&s).unwrap_or_else(|_| default_real_time_level())
+        };
+        Self {
+            leg_arrival_penalty,
+            leg_walking_penalty,
+            max_nb_of_legs,
+            max_journey_duration,
+            too_late_threshold,
+            real_time_level,
+        }
+    }
+}

--- a/launch/src/config/request_params.rs
+++ b/launch/src/config/request_params.rs
@@ -38,6 +38,8 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 use loki::{PositiveDuration, RealTimeLevel};
+
+use super::parse_env_var;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RequestParams {
@@ -115,30 +117,42 @@ impl Default for RequestParams {
 
 impl RequestParams {
     pub fn new_from_env_vars() -> Self {
-        let leg_arrival_penalty = {
-            let s = std::env::var("LOKI_LEG_ARRIVAL_PENALTY").unwrap_or_default();
-            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_leg_arrival_penalty())
-        };
-        let leg_walking_penalty = {
-            let s = std::env::var("LOKI_LEG_WALKING_PENALTY").unwrap_or_default();
-            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_leg_walking_penalty())
-        };
-        let max_nb_of_legs = {
-            let s = std::env::var("LOKI_MAX_NB_OF_LEGS").unwrap_or_default();
-            u8::from_str(&s).unwrap_or_else(|_| default_max_nb_of_legs())
-        };
-        let max_journey_duration = {
-            let s = std::env::var("LOKI_MAX_JOURNEY_DURATION").unwrap_or_default();
-            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_max_journey_duration())
-        };
-        let too_late_threshold = {
-            let s = std::env::var("LOKI_TOO_LATE_THRESHOLD").unwrap_or_default();
-            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_too_late_threshold())
-        };
-        let real_time_level = {
-            let s = std::env::var("LOKI_REAL_TIME_LEVEL").unwrap_or_default();
-            RealTimeLevel::from_str(&s).unwrap_or_else(|_| default_real_time_level())
-        };
+        let leg_arrival_penalty = parse_env_var(
+            "LOKI_LEG_ARRIVAL_PENALTY",
+            default_leg_arrival_penalty(),
+            PositiveDuration::from_str,
+        );
+
+        let leg_walking_penalty = parse_env_var(
+            "LOKI_LEG_WALKING_PENALTY",
+            default_leg_walking_penalty(),
+            PositiveDuration::from_str,
+        );
+
+        let max_nb_of_legs = parse_env_var(
+            "LOKI_MAX_NB_OF_LEGS",
+            default_max_nb_of_legs(),
+            u8::from_str,
+        );
+
+        let max_journey_duration = parse_env_var(
+            "LOKI_MAX_JOURNEY_DURATION",
+            default_max_journey_duration(),
+            PositiveDuration::from_str,
+        );
+
+        let too_late_threshold = parse_env_var(
+            "LOKI_TOO_LATE_THRESHOLD",
+            default_too_late_threshold(),
+            PositiveDuration::from_str,
+        );
+
+        let real_time_level = parse_env_var(
+            "LOKI_REAL_TIME_LEVEL",
+            default_real_time_level(),
+            RealTimeLevel::from_str,
+        );
+
         Self {
             leg_arrival_penalty,
             leg_walking_penalty,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -49,6 +49,7 @@ hyper = {version = "0.14", features = ["server", "stream"] }
 [dev-dependencies]
 shiplift = "0.7" # docker API
 tempfile = "3"
+temp-env = "0.3"
 
 [build-dependencies]
 prost-build = "0.11"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -31,7 +31,7 @@ lapin = "2.0"
 rust-s3 = "0.32"
 
 loki_launch = { path = "../launch"}
-structopt = "0.3"
+
 anyhow = "1"
 thiserror = "1"
 serde = "1.0"

--- a/server/config_files/data_in_local_folder.toml
+++ b/server/config_files/data_in_local_folder.toml
@@ -55,12 +55,12 @@ real_time_level = 'base'
 [rabbitmq]
 endpoint = 'amqp://login:password@rabbitmq_hostname:5672/navitia'
 exchange = 'navitia'
-real_time_topics = [
+realtime_topics = [
     'shortterm.my_coverage',
     'another_topic',
 ]
 
-real_time_update_interval = '00:00:30'
+realtime_update_interval = '00:00:30'
 connect_retry_interval = '00:00:10'
 reload_kirin_request_time_to_live = '00:00:02'
 reload_kirin_timeout = '00:00:10'

--- a/server/config_files/data_in_local_folder.toml
+++ b/server/config_files/data_in_local_folder.toml
@@ -62,7 +62,7 @@ real_time_topics = [
 
 real_time_update_interval = '00:00:30'
 connect_retry_interval = '00:00:10'
-reload_request_time_to_live = '00:00:02'
+reload_kirin_request_time_to_live = '00:00:02'
 reload_kirin_timeout = '00:00:10'
 reload_queue_expires = '02:00:00'
 realtime_queue_expires = '02:00:00'

--- a/server/config_files/data_in_s3.toml
+++ b/server/config_files/data_in_s3.toml
@@ -8,7 +8,7 @@ bucket_region = 'http://s3_hostname/'
 bucket_access_key = 'loki_rw'
 bucket_secret_key = 'my_secret_key'
 data_path_key = 'my_coverage/ntfs.zip'
-bucket_timeout_in_ms = 30_000
+bucket_timeout = '00:01:00'
 
 
 [default_request_params]

--- a/server/config_files/data_in_s3.toml
+++ b/server/config_files/data_in_s3.toml
@@ -28,7 +28,7 @@ real_time_topics = [
 ]
 real_time_update_interval = '00:00:30'
 connect_retry_interval = '00:00:10'
-reload_request_time_to_live = '00:00:02'
+reload_kirin_request_time_to_live = '00:00:02'
 reload_kirin_timeout = '00:00:10'
 reload_queue_expires = '02:00:00'
 realtime_queue_expires = '02:00:00'

--- a/server/config_files/data_in_s3.toml
+++ b/server/config_files/data_in_s3.toml
@@ -22,11 +22,11 @@ real_time_level = 'base'
 [rabbitmq]
 endpoint = 'amqp://login:password@rabbitmq_hostname:5672/navitia'
 exchange = 'navitia'
-real_time_topics = [
+realtime_topics = [
     'shortterm.my_coverage',
     'another_topic',
 ]
-real_time_update_interval = '00:00:30'
+realtime_update_interval = '00:00:30'
 connect_retry_interval = '00:00:10'
 reload_kirin_request_time_to_live = '00:00:02'
 reload_kirin_timeout = '00:00:10'

--- a/server/src/chaos/models.rs
+++ b/server/src/chaos/models.rs
@@ -37,7 +37,7 @@
 use crate::{
     chaos::sql_types::{ChannelType as ChannelTypeSQL, PtObjectType, SeverityEffect},
     chaos_proto, info,
-    server_config::ChaosParams,
+    server_config::chaos_params::ChaosParams,
 };
 use anyhow::{bail, Context, Error};
 use diesel::{

--- a/server/src/data_downloader.rs
+++ b/server/src/data_downloader.rs
@@ -83,7 +83,7 @@ impl DataDownloader {
             }
         };
 
-        let timeout = Duration::from_millis(u64::from(config.bucket_timeout_in_ms));
+        let timeout = Duration::from_secs(config.bucket_timeout.total_seconds());
         bucket.set_request_timeout(Some(timeout));
 
         Ok(Self {

--- a/server/src/data_downloader.rs
+++ b/server/src/data_downloader.rs
@@ -39,7 +39,7 @@ use core::time::Duration;
 use s3::{creds::Credentials, Bucket, Region};
 use std::io::Cursor;
 
-use crate::server_config::BucketParams;
+use crate::server_config::data_source_params::BucketParams;
 pub struct DataDownloader {
     bucket: Bucket,
 

--- a/server/src/data_worker.rs
+++ b/server/src/data_worker.rs
@@ -296,7 +296,7 @@ impl DataWorker {
         let interval = tokio::time::interval(Duration::from_secs(
             self.config
                 .rabbitmq
-                .real_time_update_interval
+                .realtime_update_interval
                 .total_seconds(),
         ));
         tokio::pin!(interval);
@@ -418,7 +418,7 @@ impl DataWorker {
         let chaos_disruptions_result = chaos::models::read_chaos_disruption_from_database(
             chaos_params,
             (start_date, end_date),
-            &self.config.rabbitmq.real_time_topics,
+            &self.config.rabbitmq.realtime_topics,
         );
         info!(
             "Loading chaos disruptions from database completed in {} ms",
@@ -702,7 +702,7 @@ impl DataWorker {
             declare_queue(channel, queue_name, durable, exclusive, expires).await?;
 
             let exchange = &self.config.rabbitmq.exchange;
-            let topics = &self.config.rabbitmq.real_time_topics;
+            let topics = &self.config.rabbitmq.realtime_topics;
             bind_queue(channel, queue_name, exchange, topics).await?;
 
             self.send_status_update(StatusUpdate::RealTimeQueueCreated)?;
@@ -783,7 +783,7 @@ impl DataWorker {
 
             let load_realtime = navitia_proto::LoadRealtime {
                 queue_name: queue_name.clone(),
-                contributors: self.config.rabbitmq.real_time_topics.clone(),
+                contributors: self.config.rabbitmq.realtime_topics.clone(),
                 begin_date: Some(start_date),
                 end_date: Some(end_date),
             };

--- a/server/src/data_worker.rs
+++ b/server/src/data_worker.rs
@@ -89,7 +89,7 @@ use std::{
 
 use crate::{
     data_downloader::DataDownloader, handle_chaos_message::handle_chaos_protobuf,
-    server_config::DataSourceParams,
+    server_config::data_source_params::DataSourceParams,
 };
 use loki_launch::config::launch_params::LocalFileParams;
 use tokio::{runtime::Builder, sync::mpsc, time::Duration};
@@ -798,7 +798,7 @@ impl DataWorker {
             "{}",
             self.config
                 .rabbitmq
-                .reload_request_time_to_live
+                .reload_kirin_request_time_to_live
                 .total_seconds()
                 * 1000
         );

--- a/server/src/http_worker.rs
+++ b/server/src/http_worker.rs
@@ -35,7 +35,7 @@ use hyper::{
 use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info};
 
-use crate::{server_config::HttpParams, status_worker::Status};
+use crate::{server_config::http_params::HttpParams, status_worker::Status};
 
 pub struct HttpToStatusChannel {
     // http worker will send a oneshot::Sender through `status_request_receiver`

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -86,7 +86,7 @@ pub fn launch_server() -> Result<(), Error> {
             ))?
         }
         _ => {
-            anyhow::bail!("Unexpected number of arguments {}", args.len());
+            anyhow::bail!("Unexpected number of arguments {}.", args.len());
         }
     };
     debug!("Launching with config : {:#?}", config);

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -77,10 +77,11 @@ pub fn launch_server() -> Result<(), Error> {
     let config = match args.len() {
         1 => ServerConfig::new_from_env_vars().context("Could not read config from env vars")?,
         2 => {
-            let _ = args.next();
+            // skip the first arg which is the name of the binary launched
+            args.next();
             // unwrap is safe, we checked that args has at least 2 elements
             let config_file_path = args.next().unwrap();
-            read_config(&Path::new(&config_file_path)).context(format!(
+            read_config(Path::new(&config_file_path)).context(format!(
                 "Could not read config from file path {}",
                 config_file_path
             ))?

--- a/server/src/server_config.rs
+++ b/server/src/server_config.rs
@@ -34,6 +34,13 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
+pub mod chaos_params;
+pub mod data_source_params;
+pub mod http_params;
+pub mod rabbitmq_params;
+
+use anyhow::{Context, Error};
+use loki_launch::config::RequestParams;
 use loki_launch::{config, loki::PositiveDuration};
 
 use loki_launch::config::{
@@ -42,6 +49,11 @@ use loki_launch::config::{
 };
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, str::FromStr};
+
+use self::chaos_params::ChaosParams;
+use self::data_source_params::DataSourceParams;
+use self::http_params::HttpParams;
+use self::rabbitmq_params::RabbitMqParams;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -84,17 +96,6 @@ pub struct ServerConfig {
     pub http: HttpParams,
 }
 
-pub fn default_nb_workers() -> u16 {
-    1
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum DataSourceParams {
-    Local(LocalFileParams),
-    S3(BucketParams),
-}
-
 impl ServerConfig {
     pub fn new(input_data_path: std::path::PathBuf, zmq_socket: &str, instance_name: &str) -> Self {
         Self {
@@ -113,187 +114,57 @@ impl ServerConfig {
             nb_workers: default_nb_workers(),
         }
     }
-}
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct RabbitMqParams {
-    #[serde(default = "default_rabbitmq_endpoint")]
-    pub endpoint: String,
+    pub fn new_from_env_vars() -> Result<Self, Error> {
+        let instance_name = std::env::var("LOKI_INSTANCE_NAME")
+            .context("Could not read mandatory env var LOKI_INSTANCE_NAME")?;
 
-    #[serde(default = "default_rabbitmq_exchange")]
-    pub exchange: String,
+        let requests_socket = std::env::var("LOKI_REQUESTS_SOCKET")
+            .context("Could not read read mandatory env var LOKI_REQUESTS_SOCKET")?;
 
-    #[serde(default = "default_rabbitmq_real_time_topics")]
-    pub real_time_topics: Vec<String>,
+        let input_data_type = {
+            let s = std::env::var("LOKI_INPUT_DATA_TYPE").unwrap_or_default();
+            InputDataType::from_str(&s).unwrap_or_default()
+        };
 
-    #[serde(default = "default_real_time_update_interval")]
-    pub real_time_update_interval: PositiveDuration,
+        let default_transfer_duration = {
+            let s = std::env::var("LOKI_DEFAULT_TRANSFER_DURATION").unwrap_or_default();
+            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_transfer_duration())
+        };
 
-    #[serde(default = "default_rabbitmq_connect_retry_interval")]
-    pub connect_retry_interval: PositiveDuration,
+        let nb_workers = {
+            let s = std::env::var("LOKI_NB_WORKERS").unwrap_or_default();
+            u16::from_str(&s).unwrap_or_else(|_| default_nb_workers())
+        };
 
-    #[serde(default = "default_reload_request_time_to_live")]
-    pub reload_request_time_to_live: PositiveDuration,
+        let data_source = DataSourceParams::new_from_env_vars()
+            .context("Could not read DataSourceParams from env vars")?;
 
-    #[serde(default = "default_reload_kirin_timeout")]
-    pub reload_kirin_timeout: PositiveDuration,
+        let default_request_params = RequestParams::new_from_env_vars();
 
-    #[serde(default = "default_reload_queue_expires")]
-    pub reload_queue_expires: PositiveDuration,
+        let rabbitmq = RabbitMqParams::new_from_env_vars();
 
-    #[serde(default = "default_realtime_queue_expires")]
-    pub realtime_queue_expires: PositiveDuration,
-}
+        let chaos = ChaosParams::new_from_env_vars().ok();
 
-pub fn default_rabbitmq_endpoint() -> String {
-    "amqp://guest:guest@rabbitmq:5672".to_string()
-}
+        let http = HttpParams::new_from_env_vars();
 
-pub fn default_rabbitmq_exchange() -> String {
-    "navitia".to_string()
-}
-
-pub fn default_rabbitmq_real_time_topics() -> Vec<String> {
-    Vec::new()
-}
-
-pub fn default_real_time_update_interval() -> PositiveDuration {
-    PositiveDuration::from_str("00:00:30").unwrap()
-}
-
-pub fn default_rabbitmq_connect_retry_interval() -> PositiveDuration {
-    PositiveDuration::from_str("00:00:10").unwrap()
-}
-
-pub fn default_reload_request_time_to_live() -> PositiveDuration {
-    PositiveDuration::from_str("00:00:02").unwrap()
-}
-
-pub fn default_reload_kirin_timeout() -> PositiveDuration {
-    PositiveDuration::from_str("00:00:10").unwrap()
-}
-
-pub fn default_reload_queue_expires() -> PositiveDuration {
-    PositiveDuration::from_str("02:00:00").unwrap()
-}
-
-pub fn default_realtime_queue_expires() -> PositiveDuration {
-    PositiveDuration::from_str("02:00:00").unwrap()
-}
-
-impl Default for RabbitMqParams {
-    fn default() -> Self {
-        Self {
-            endpoint: default_rabbitmq_endpoint(),
-            exchange: default_rabbitmq_exchange(),
-            real_time_topics: default_rabbitmq_real_time_topics(),
-            real_time_update_interval: default_real_time_update_interval(),
-            connect_retry_interval: default_rabbitmq_connect_retry_interval(),
-            reload_request_time_to_live: default_reload_request_time_to_live(),
-            reload_kirin_timeout: default_reload_kirin_timeout(),
-            reload_queue_expires: default_reload_queue_expires(),
-            realtime_queue_expires: default_realtime_queue_expires(),
-        }
+        Ok(Self {
+            instance_name,
+            requests_socket,
+            input_data_type,
+            default_transfer_duration,
+            nb_workers,
+            data_source,
+            default_request_params,
+            rabbitmq,
+            chaos,
+            http,
+        })
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct ChaosParams {
-    /// connection string to the chaos database
-    /// for example : "postgres://guest:guest@localhost:5432/chaos"
-    pub database: String,
-
-    /// During reload of chaos disruption
-    /// we will ask the database to send
-    /// blocks of rows of size `batch_size`
-    #[serde(default = "default_batch_size")]
-    pub batch_size: u32,
-}
-
-pub fn default_batch_size() -> u32 {
-    1_000_000
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct BucketParams {
-    #[serde(default = "default_bucket_name")]
-    pub bucket_name: String,
-
-    #[serde(default = "default_bucket_region")]
-    pub bucket_region: String,
-
-    #[serde(default)]
-    pub bucket_access_key: String,
-
-    #[serde(default)]
-    pub bucket_secret_key: String,
-
-    #[serde(default)]
-    pub data_path_key: String,
-
-    #[serde(default = "default_bucket_timeout_in_ms")]
-    pub bucket_timeout_in_ms: u32,
-}
-
-pub fn default_bucket_name() -> String {
-    "loki".to_string()
-}
-
-pub fn default_bucket_region() -> String {
-    "eu-west-1".to_string()
-}
-
-pub fn default_bucket_timeout_in_ms() -> u32 {
-    30_000
-}
-
-impl Default for BucketParams {
-    fn default() -> Self {
-        BucketParams {
-            bucket_name: default_bucket_name(),
-            bucket_region: default_bucket_region(),
-            bucket_access_key: "".to_string(),
-            bucket_secret_key: "".to_string(),
-            data_path_key: "".to_string(),
-            bucket_timeout_in_ms: default_bucket_timeout_in_ms(),
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct HttpParams {
-    /// http endpoint for health and status checks
-    /// Something like 127.0.0.1:30000
-    /// will provide two routes
-    /// - http://127.0.0.1:3000/status
-    /// - http://127.0.0.1:3000/health
-    #[serde(default = "default_http_address")]
-    pub http_address: std::net::SocketAddr,
-
-    /// How long to wait before deciding that the request failed
-    #[serde(default = "default_http_request_timeout")]
-    pub http_request_timeout: PositiveDuration,
-}
-
-pub fn default_http_address() -> std::net::SocketAddr {
-    ([127, 0, 0, 1], 3000).into()
-}
-
-pub fn default_http_request_timeout() -> PositiveDuration {
-    PositiveDuration::from_hms(0, 0, 10)
-}
-
-impl Default for HttpParams {
-    fn default() -> Self {
-        Self {
-            http_address: default_http_address(),
-            http_request_timeout: default_http_request_timeout(),
-        }
-    }
+pub fn default_nb_workers() -> u16 {
+    1
 }
 
 #[cfg(test)]

--- a/server/src/server_config/chaos_params.rs
+++ b/server/src/server_config/chaos_params.rs
@@ -34,68 +34,40 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use std::path::PathBuf;
-
-use super::InputDataType;
 use anyhow::Context;
-use loki::PositiveDuration;
 
 use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, str::FromStr};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct LaunchParams {
-    /// directory containing ntfs/gtfs files to load
-    pub input_data_path: std::path::PathBuf,
+pub struct ChaosParams {
+    /// connection string to the chaos database
+    /// for example : "postgres://guest:guest@localhost:5432/chaos"
+    pub database: String,
 
-    /// type of input data given (ntfs/gtfs)
-    #[serde(default)]
-    pub input_data_type: InputDataType,
-
-    /// path to the passengers loads file
-    pub loads_data_path: Option<std::path::PathBuf>,
-
-    /// the transfer duration between a stop point and itself
-    #[serde(default = "default_transfer_duration")]
-    pub default_transfer_duration: PositiveDuration,
+    /// During reload of chaos disruption
+    /// we will ask the database to send
+    /// blocks of rows of size `batch_size`
+    #[serde(default = "default_batch_size")]
+    pub batch_size: u32,
 }
 
-pub const DEFAULT_TRANSFER_DURATION: &str = "00:01:00";
-
-pub fn default_transfer_duration() -> PositiveDuration {
-    use std::str::FromStr;
-    PositiveDuration::from_str(DEFAULT_TRANSFER_DURATION).unwrap()
+pub fn default_batch_size() -> u32 {
+    1_000_000
 }
 
-impl LaunchParams {
-    pub fn new(input_data_path: std::path::PathBuf) -> Self {
-        Self {
-            input_data_path,
-            input_data_type: InputDataType::Ntfs,
-            default_transfer_duration: default_transfer_duration(),
-            loads_data_path: None,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct LocalFileParams {
-    pub input_data_path: std::path::PathBuf,
-    pub loads_data_path: Option<std::path::PathBuf>,
-}
-
-impl LocalFileParams {
+impl ChaosParams {
     pub fn new_from_env_vars() -> Result<Self, anyhow::Error> {
-        let input_data_path = std::env::var("LOKI_INPUT_DATA_PATH")
-            .map(|s| PathBuf::from(s))
-            .context("Could not read mandatory env var LOKI_INPUT_DATA_PATH")?;
-        let loads_data_path = std::env::var("LOKI_LOADS_DATA_PATH")
-            .map(|s| Some(PathBuf::from(s)))
-            .unwrap_or(None);
+        let database = std::env::var("LOKI_CHAOS_DATABASE")
+            .context("Could not read mandatory env var LOKI_CHAOS_DATABASE")?;
+        let batch_size = {
+            let string = std::env::var("CHAOS_BATCH_SIZE").unwrap_or_default();
+            u32::from_str(&string).unwrap_or_else(|_| default_batch_size())
+        };
         Ok(Self {
-            input_data_path,
-            loads_data_path,
+            database,
+            batch_size,
         })
     }
 }

--- a/server/src/server_config/chaos_params.rs
+++ b/server/src/server_config/chaos_params.rs
@@ -62,6 +62,7 @@ impl ChaosParams {
     pub fn new_from_env_vars() -> Result<Self, anyhow::Error> {
         let database = std::env::var("LOKI_CHAOS_DATABASE")
             .context("Could not read mandatory env var LOKI_CHAOS_DATABASE")?;
+
         let batch_size =
             parse_env_var("LOKI_CHAOS_BATCH_SIZE", default_batch_size(), u32::from_str);
 

--- a/server/src/server_config/chaos_params.rs
+++ b/server/src/server_config/chaos_params.rs
@@ -36,6 +36,7 @@
 
 use anyhow::Context;
 
+use loki_launch::config::parse_env_var;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, str::FromStr};
 
@@ -61,10 +62,9 @@ impl ChaosParams {
     pub fn new_from_env_vars() -> Result<Self, anyhow::Error> {
         let database = std::env::var("LOKI_CHAOS_DATABASE")
             .context("Could not read mandatory env var LOKI_CHAOS_DATABASE")?;
-        let batch_size = {
-            let string = std::env::var("CHAOS_BATCH_SIZE").unwrap_or_default();
-            u32::from_str(&string).unwrap_or_else(|_| default_batch_size())
-        };
+        let batch_size =
+            parse_env_var("LOKI_CHAOS_BATCH_SIZE", default_batch_size(), u32::from_str);
+
         Ok(Self {
             database,
             batch_size,

--- a/server/src/server_config/data_source_params.rs
+++ b/server/src/server_config/data_source_params.rs
@@ -1,0 +1,157 @@
+// Copyright  (C) 2020, Hove and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+// the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+// powered by Hove (www.kisio.com).
+// Help us simplify mobility and open public transport:
+// a non ending quest to the responsive locomotion way of traveling!
+//
+// This contribution is a part of the research and development work of the
+// IVA Project which aims to enhance traveler information and is carried out
+// under the leadership of the Technological Research Institute SystemX,
+// with the partnership and support of the transport organization authority
+// Ile-De-France Mobilités (IDFM), SNCF, and public funds
+// under the scope of the French Program "Investissements d’Avenir".
+//
+// LICENCE: This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+use anyhow::{Context, Error};
+
+use loki_launch::config::launch_params::LocalFileParams;
+use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, str::FromStr};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DataSourceParams {
+    Local(LocalFileParams),
+    S3(BucketParams),
+}
+
+impl DataSourceParams {
+    pub fn new_from_env_vars() -> Result<Self, Error> {
+        let data_source_type = std::env::var("LOKI_DATA_SOURCE_TYPE")
+            .context("Could not read mandatory env var LOKI_INSTANCE_NAME")?;
+        match data_source_type.trim() {
+            "s3" => {
+                let bucket_params = BucketParams::new_from_env_vars();
+                Ok(DataSourceParams::S3(bucket_params))
+            }
+            "local" => {
+                let local_file_params = LocalFileParams::new_from_env_vars()
+                    .context("LOKI_DATA_SOURCE_TYPE is set to 'local' but I could not read local file params from env vars")?;
+                Ok(DataSourceParams::Local(local_file_params))
+            }
+            _ => {
+                anyhow::bail!(
+                    "Bad LOKI_DATA_SOURCE_TYPE : {}. Allowed values are 's3' or 'local'",
+                    data_source_type
+                );
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct BucketParams {
+    #[serde(default = "default_bucket_name")]
+    pub bucket_name: String,
+
+    #[serde(default = "default_bucket_region")]
+    pub bucket_region: String,
+
+    #[serde(default = "default_bucket_access_key")]
+    pub bucket_access_key: String,
+
+    #[serde(default = "default_bucket_secret_key")]
+    pub bucket_secret_key: String,
+
+    #[serde(default = "default_data_path")]
+    pub data_path_key: String,
+
+    #[serde(default = "default_bucket_timeout_in_ms")]
+    pub bucket_timeout_in_ms: u32,
+}
+
+pub fn default_bucket_name() -> String {
+    "loki".to_string()
+}
+
+pub fn default_bucket_region() -> String {
+    "eu-west-1".to_string()
+}
+
+pub fn default_bucket_access_key() -> String {
+    "".to_string()
+}
+
+pub fn default_bucket_secret_key() -> String {
+    "".to_string()
+}
+
+pub fn default_data_path() -> String {
+    "".to_string()
+}
+
+pub fn default_bucket_timeout_in_ms() -> u32 {
+    30_000
+}
+
+impl BucketParams {
+    pub fn default() -> Self {
+        BucketParams {
+            bucket_name: default_bucket_name(),
+            bucket_region: default_bucket_region(),
+            bucket_access_key: default_bucket_access_key(),
+            bucket_secret_key: default_bucket_secret_key(),
+            data_path_key: default_data_path(),
+            bucket_timeout_in_ms: default_bucket_timeout_in_ms(),
+        }
+    }
+
+    pub fn new_from_env_vars() -> Self {
+        let bucket_name =
+            std::env::var("LOKI_BUCKET_NAME").unwrap_or_else(|_| default_bucket_name());
+        let bucket_region =
+            std::env::var("LOKI_BUCKET_REGION").unwrap_or_else(|_| default_bucket_region());
+        let bucket_access_key =
+            std::env::var("LOKI_BUCKET_ACCESS_KEY").unwrap_or_else(|_| default_bucket_access_key());
+        let bucket_secret_key =
+            std::env::var("LOKI_BUCKET_SECRET_KEY").unwrap_or_else(|_| default_bucket_secret_key());
+        let data_path_key =
+            std::env::var("LOKI_BUCKET_DATA_PATH").unwrap_or_else(|_| default_data_path());
+        let bucket_timeout_in_ms = {
+            let string = std::env::var("LOKI_BUCKET_TIMEOUT_IN_MS").unwrap_or_default();
+            u32::from_str(&string).unwrap_or_else(|_| default_bucket_timeout_in_ms())
+        };
+
+        Self {
+            bucket_name,
+            bucket_region,
+            bucket_access_key,
+            bucket_secret_key,
+            data_path_key,
+            bucket_timeout_in_ms,
+        }
+    }
+}

--- a/server/src/server_config/data_source_params.rs
+++ b/server/src/server_config/data_source_params.rs
@@ -50,7 +50,7 @@ pub enum DataSourceParams {
 impl DataSourceParams {
     pub fn new_from_env_vars() -> Result<Self, Error> {
         let data_source_type = std::env::var("LOKI_DATA_SOURCE_TYPE")
-            .context("Could not read mandatory env var LOKI_INSTANCE_NAME")?;
+            .context("Could not read mandatory env var LOKI_DATA_SOURCE_TYPE")?;
         match data_source_type.trim() {
             "s3" => {
                 let bucket_params = BucketParams::new_from_env_vars();

--- a/server/src/server_config/data_source_params.rs
+++ b/server/src/server_config/data_source_params.rs
@@ -135,6 +135,7 @@ impl BucketParams {
     pub fn new_from_env_vars() -> Self {
         let bucket_name =
             read_env_var("LOKI_BUCKET_NAME", default_bucket_name(), |s| s.to_string());
+
         let bucket_region = read_env_var("LOKI_BUCKET_REGION", default_bucket_region(), |s| {
             s.to_string()
         });
@@ -152,7 +153,7 @@ impl BucketParams {
         });
 
         let bucket_timeout = parse_env_var(
-            "LOKI_BUCKET_TIMEOUT_IN_MS",
+            "LOKI_BUCKET_TIMEOUT",
             default_bucket_timeout(),
             PositiveDuration::from_str,
         );

--- a/server/src/server_config/data_source_params.rs
+++ b/server/src/server_config/data_source_params.rs
@@ -63,7 +63,7 @@ impl DataSourceParams {
             }
             _ => {
                 anyhow::bail!(
-                    "Bad LOKI_DATA_SOURCE_TYPE : {}. Allowed values are 's3' or 'local'",
+                    "Bad LOKI_DATA_SOURCE_TYPE : '{}'. Allowed values are 's3' or 'local'",
                     data_source_type
                 );
             }

--- a/server/src/server_config/http_params.rs
+++ b/server/src/server_config/http_params.rs
@@ -34,7 +34,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use loki_launch::loki::PositiveDuration;
+use loki_launch::{config::parse_env_var, loki::PositiveDuration};
 
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, str::FromStr};
@@ -74,14 +74,18 @@ impl Default for HttpParams {
 
 impl HttpParams {
     pub fn new_from_env_vars() -> Self {
-        let http_address = {
-            let s = std::env::var("LOKI_HTTP_ADDRESS").unwrap_or_default();
-            std::net::SocketAddr::from_str(&s).unwrap_or_else(|_| default_http_address())
-        };
-        let http_request_timeout = {
-            let s = std::env::var("LOKI_HTTP_REQUEST_TIMEOUT").unwrap_or_default();
-            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_http_request_timeout())
-        };
+        let http_address = parse_env_var(
+            "LOKI_HTTP_ADDRESS",
+            default_http_address(),
+            std::net::SocketAddr::from_str,
+        );
+
+        let http_request_timeout = parse_env_var(
+            "LOKI_HTTP_REQUEST_TIMEOUT",
+            default_http_request_timeout(),
+            PositiveDuration::from_str,
+        );
+
         Self {
             http_address,
             http_request_timeout,

--- a/server/src/server_config/rabbitmq_params.rs
+++ b/server/src/server_config/rabbitmq_params.rs
@@ -49,10 +49,10 @@ pub struct RabbitMqParams {
     pub exchange: String,
 
     #[serde(default = "default_real_time_topics")]
-    pub real_time_topics: Vec<String>,
+    pub realtime_topics: Vec<String>,
 
     #[serde(default = "default_real_time_update_interval")]
-    pub real_time_update_interval: PositiveDuration,
+    pub realtime_update_interval: PositiveDuration,
 
     #[serde(default = "default_connect_retry_interval")]
     pub connect_retry_interval: PositiveDuration,
@@ -111,8 +111,8 @@ impl Default for RabbitMqParams {
         Self {
             endpoint: default_endpoint(),
             exchange: default_exchange(),
-            real_time_topics: default_real_time_topics(),
-            real_time_update_interval: default_real_time_update_interval(),
+            realtime_topics: default_real_time_topics(),
+            realtime_update_interval: default_real_time_update_interval(),
             connect_retry_interval: default_connect_retry_interval(),
             reload_kirin_request_time_to_live: default_reload_kirin_request_time_to_live(),
             reload_kirin_timeout: default_reload_kirin_timeout(),
@@ -128,15 +128,14 @@ impl RabbitMqParams {
             std::env::var("LOKI_RABBITMQ_ENDPOINT").unwrap_or_else(|_| default_endpoint());
         let exchange =
             std::env::var("LOKI_RABBITMQ_EXCHANGE").unwrap_or_else(|_| default_exchange());
-        let real_time_topics: Vec<String> = {
-            let string = std::env::var("LOKI_REAL_TIME_TOPICS").unwrap_or_default();
-            let trimmed = string.trim();
+        let realtime_topics: Vec<String> = {
+            let string = std::env::var("LOKI_REALTIME_TOPICS").unwrap_or_default();
             // split at ";" characters
-            let iter = trimmed.split_terminator(";");
+            let iter = string.split_terminator(';');
             iter.map(|substring| substring.trim().to_string()).collect()
         };
-        let real_time_update_interval = {
-            let s = std::env::var("LOKI_REAL_TIME_UPDATE_INTERVAL").unwrap_or_default();
+        let realtime_update_interval = {
+            let s = std::env::var("LOKI_REALTIME_UPDATE_INTERVAL").unwrap_or_default();
             PositiveDuration::from_str(&s).unwrap_or_else(|_| default_real_time_update_interval())
         };
         let connect_retry_interval = {
@@ -163,8 +162,8 @@ impl RabbitMqParams {
         Self {
             endpoint,
             exchange,
-            real_time_topics,
-            real_time_update_interval,
+            realtime_topics,
+            realtime_update_interval,
             connect_retry_interval,
             reload_kirin_request_time_to_live,
             reload_kirin_timeout,

--- a/server/src/server_config/rabbitmq_params.rs
+++ b/server/src/server_config/rabbitmq_params.rs
@@ -1,0 +1,175 @@
+// Copyright  (C) 2020, Hove and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+// the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+// powered by Hove (www.kisio.com).
+// Help us simplify mobility and open public transport:
+// a non ending quest to the responsive locomotion way of traveling!
+//
+// This contribution is a part of the research and development work of the
+// IVA Project which aims to enhance traveler information and is carried out
+// under the leadership of the Technological Research Institute SystemX,
+// with the partnership and support of the transport organization authority
+// Ile-De-France Mobilités (IDFM), SNCF, and public funds
+// under the scope of the French Program "Investissements d’Avenir".
+//
+// LICENCE: This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+use loki_launch::loki::PositiveDuration;
+
+use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, str::FromStr};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct RabbitMqParams {
+    #[serde(default = "default_endpoint")]
+    pub endpoint: String,
+
+    #[serde(default = "default_exchange")]
+    pub exchange: String,
+
+    #[serde(default = "default_real_time_topics")]
+    pub real_time_topics: Vec<String>,
+
+    #[serde(default = "default_real_time_update_interval")]
+    pub real_time_update_interval: PositiveDuration,
+
+    #[serde(default = "default_connect_retry_interval")]
+    pub connect_retry_interval: PositiveDuration,
+
+    #[serde(default = "default_reload_kirin_request_time_to_live")]
+    pub reload_kirin_request_time_to_live: PositiveDuration,
+
+    #[serde(default = "default_reload_kirin_timeout")]
+    pub reload_kirin_timeout: PositiveDuration,
+
+    #[serde(default = "default_reload_queue_expires")]
+    pub reload_queue_expires: PositiveDuration,
+
+    #[serde(default = "default_realtime_queue_expires")]
+    pub realtime_queue_expires: PositiveDuration,
+}
+
+pub fn default_endpoint() -> String {
+    "amqp://guest:guest@rabbitmq:5672".to_string()
+}
+
+pub fn default_exchange() -> String {
+    "navitia".to_string()
+}
+
+pub fn default_real_time_topics() -> Vec<String> {
+    Vec::new()
+}
+
+pub fn default_real_time_update_interval() -> PositiveDuration {
+    PositiveDuration::from_str("00:00:30").unwrap()
+}
+
+pub fn default_connect_retry_interval() -> PositiveDuration {
+    PositiveDuration::from_str("00:00:10").unwrap()
+}
+
+pub fn default_reload_kirin_request_time_to_live() -> PositiveDuration {
+    PositiveDuration::from_str("00:00:02").unwrap()
+}
+
+pub fn default_reload_kirin_timeout() -> PositiveDuration {
+    PositiveDuration::from_str("00:00:10").unwrap()
+}
+
+pub fn default_reload_queue_expires() -> PositiveDuration {
+    PositiveDuration::from_str("02:00:00").unwrap()
+}
+
+pub fn default_realtime_queue_expires() -> PositiveDuration {
+    PositiveDuration::from_str("02:00:00").unwrap()
+}
+
+impl Default for RabbitMqParams {
+    fn default() -> Self {
+        Self {
+            endpoint: default_endpoint(),
+            exchange: default_exchange(),
+            real_time_topics: default_real_time_topics(),
+            real_time_update_interval: default_real_time_update_interval(),
+            connect_retry_interval: default_connect_retry_interval(),
+            reload_kirin_request_time_to_live: default_reload_kirin_request_time_to_live(),
+            reload_kirin_timeout: default_reload_kirin_timeout(),
+            reload_queue_expires: default_reload_queue_expires(),
+            realtime_queue_expires: default_realtime_queue_expires(),
+        }
+    }
+}
+
+impl RabbitMqParams {
+    pub fn new_from_env_vars() -> Self {
+        let endpoint =
+            std::env::var("LOKI_RABBITMQ_ENDPOINT").unwrap_or_else(|_| default_endpoint());
+        let exchange =
+            std::env::var("LOKI_RABBITMQ_EXCHANGE").unwrap_or_else(|_| default_exchange());
+        let real_time_topics: Vec<String> = {
+            let string = std::env::var("LOKI_REAL_TIME_TOPICS").unwrap_or_default();
+            let trimmed = string.trim();
+            // split at ";" characters
+            let iter = trimmed.split_terminator(";");
+            iter.map(|substring| substring.trim().to_string()).collect()
+        };
+        let real_time_update_interval = {
+            let s = std::env::var("LOKI_REAL_TIME_UPDATE_INTERVAL").unwrap_or_default();
+            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_real_time_update_interval())
+        };
+        let connect_retry_interval = {
+            let s = std::env::var("LOKI_RABBITMQ_CONNECT_RETRY_INTERVAL").unwrap_or_default();
+            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_connect_retry_interval())
+        };
+        let reload_kirin_request_time_to_live = {
+            let s = std::env::var("LOKI_RELOAD_KIRIN_REQUEST_TIME_TO_LIVE").unwrap_or_default();
+            PositiveDuration::from_str(&s)
+                .unwrap_or_else(|_| default_reload_kirin_request_time_to_live())
+        };
+        let reload_kirin_timeout = {
+            let s = std::env::var("LOKI_RELOAD_KIRIN_TIMEOUT").unwrap_or_default();
+            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_reload_kirin_timeout())
+        };
+        let reload_queue_expires = {
+            let s = std::env::var("LOKI_RELOAD_QUEUE_EXPIRES").unwrap_or_default();
+            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_reload_queue_expires())
+        };
+        let realtime_queue_expires = {
+            let s = std::env::var("LOKI_REALTIME_QUEUE_EXPIRES").unwrap_or_default();
+            PositiveDuration::from_str(&s).unwrap_or_else(|_| default_realtime_queue_expires())
+        };
+        Self {
+            endpoint,
+            exchange,
+            real_time_topics,
+            real_time_update_interval,
+            connect_retry_interval,
+            reload_kirin_request_time_to_live,
+            reload_kirin_timeout,
+            reload_queue_expires,
+            realtime_queue_expires,
+        }
+    }
+}

--- a/server/src/server_config/rabbitmq_params.rs
+++ b/server/src/server_config/rabbitmq_params.rs
@@ -130,6 +130,7 @@ impl RabbitMqParams {
         let endpoint = read_env_var("LOKI_RABBITMQ_ENDPOINT", default_endpoint(), |s| {
             s.to_string()
         });
+
         let exchange = read_env_var("LOKI_RABBITMQ_EXCHANGE", default_exchange(), |s| {
             s.to_string()
         });
@@ -199,37 +200,45 @@ mod tests {
 
     #[test]
     fn test_single_topic() {
-        std::env::set_var("LOKI_REALTIME_TOPICS", "my-topic");
-        let params = RabbitMqParams::new_from_env_vars();
+        temp_env::with_var("LOKI_REALTIME_TOPICS", Some("my-topic"), || {
+            let params = RabbitMqParams::new_from_env_vars();
 
-        assert_eq!(params.realtime_topics, vec!["my-topic"]);
-        std::env::remove_var("LOKI_REALTIME_TOPICS");
+            assert_eq!(params.realtime_topics, vec!["my-topic"]);
+        })
     }
 
     #[test]
     fn test_two_topics() {
-        std::env::set_var("LOKI_REALTIME_TOPICS", "my-topic; my.other.topic");
-        let params = RabbitMqParams::new_from_env_vars();
+        temp_env::with_var(
+            "LOKI_REALTIME_TOPICS",
+            Some("my-topic; my.other.topic"),
+            || {
+                let params = RabbitMqParams::new_from_env_vars();
 
-        assert_eq!(params.realtime_topics, vec!["my-topic", "my.other.topic"]);
-        std::env::remove_var("LOKI_REALTIME_TOPICS");
+                assert_eq!(params.realtime_topics, vec!["my-topic", "my.other.topic"]);
+            },
+        )
     }
 
     #[test]
     fn test_middle_topic_empty() {
-        std::env::set_var("LOKI_REALTIME_TOPICS", "my-topic; ; my.other.topic");
-        let params = RabbitMqParams::new_from_env_vars();
+        temp_env::with_var(
+            "LOKI_REALTIME_TOPICS",
+            Some("my-topic; ; my.other.topic"),
+            || {
+                let params = RabbitMqParams::new_from_env_vars();
 
-        assert_eq!(params.realtime_topics, vec!["my-topic", "my.other.topic"]);
-        std::env::remove_var("LOKI_REALTIME_TOPICS");
+                assert_eq!(params.realtime_topics, vec!["my-topic", "my.other.topic"]);
+            },
+        )
     }
 
     #[test]
     fn test_empty_topics() {
-        std::env::set_var("LOKI_REALTIME_TOPICS", " ; ;");
-        let params = RabbitMqParams::new_from_env_vars();
+        temp_env::with_var("LOKI_REALTIME_TOPICS", Some(" ; ;"), || {
+            let params = RabbitMqParams::new_from_env_vars();
 
-        assert!(params.realtime_topics.is_empty());
-        std::env::remove_var("LOKI_REALTIME_TOPICS");
+            assert!(params.realtime_topics.is_empty());
+        })
     }
 }

--- a/server/src/status_worker.rs
+++ b/server/src/status_worker.rs
@@ -104,7 +104,7 @@ pub struct BaseDataInfo {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ConfigInfo {
     pub instance_name: String,
-    pub real_time_contributors: Vec<String>,
+    pub realtime_contributors: Vec<String>,
     pub nb_workers: u16,
 }
 
@@ -134,7 +134,7 @@ impl StatusWorker {
                 base_data_info: None,
                 config_info: ConfigInfo {
                     instance_name: server_config.instance_name.clone(),
-                    real_time_contributors: server_config.rabbitmq.real_time_topics.clone(),
+                    realtime_contributors: server_config.rabbitmq.realtime_topics.clone(),
                     nb_workers: server_config.nb_workers,
                 },
                 last_load_succeeded: false,
@@ -283,7 +283,7 @@ impl StatusWorker {
 
         proto_status.navitia_version = Some(self.status.loki_version.clone());
         proto_status.nb_threads = Some(i32::from(self.status.config_info.nb_workers));
-        for rt_contributors in &self.status.config_info.real_time_contributors {
+        for rt_contributors in &self.status.config_info.realtime_contributors {
             proto_status.rt_contributors.push(rt_contributors.clone());
         }
 

--- a/server/tests/main_test.rs
+++ b/server/tests/main_test.rs
@@ -41,7 +41,7 @@ use loki_server::{
     chaos_proto,
     master_worker::MasterWorker,
     navitia_proto,
-    server_config::{self, ChaosParams, HttpParams, ServerConfig},
+    server_config::{self, chaos_params::ChaosParams, http_params::HttpParams, ServerConfig},
     status_worker,
 };
 use prost::Message;
@@ -90,7 +90,7 @@ async fn run() {
     let mut config = ServerConfig::new(input_data_path, zmq_endpoint, instance_name);
     let chaos_params = ChaosParams {
         database: chaos_endpoint.to_string(),
-        batch_size: server_config::default_batch_size(),
+        batch_size: server_config::chaos_params::default_batch_size(),
     };
     config.chaos = Some(chaos_params.clone());
     config.rabbitmq.endpoint = rabbitmq_endpoint.to_string();

--- a/server/tests/main_test.rs
+++ b/server/tests/main_test.rs
@@ -96,10 +96,10 @@ async fn run() {
     config.rabbitmq.endpoint = rabbitmq_endpoint.to_string();
     config.rabbitmq.reload_kirin_timeout = PositiveDuration::from_hms(0, 0, 1);
     config.rabbitmq.connect_retry_interval = PositiveDuration::from_hms(0, 0, 2);
-    config.rabbitmq.real_time_update_interval = PositiveDuration::from_hms(0, 0, 1);
+    config.rabbitmq.realtime_update_interval = PositiveDuration::from_hms(0, 0, 1);
     config
         .rabbitmq
-        .real_time_topics
+        .realtime_topics
         .push("test_realtime_topic".to_string());
 
     wait_until_connected_to_postgresql(&chaos_params.database).await;
@@ -418,7 +418,7 @@ async fn send_realtime_message_and_wait_until_reception(
     let mut payload = Vec::new();
     realtime_message.write_to_vec(&mut payload).unwrap();
 
-    let routing_key = &config.rabbitmq.real_time_topics[0];
+    let routing_key = &config.rabbitmq.realtime_topics[0];
     channel
         .basic_publish(
             &config.rabbitmq.exchange,

--- a/server/tests/subtests/http_test.rs
+++ b/server/tests/subtests/http_test.rs
@@ -31,7 +31,7 @@ use std::str::FromStr;
 
 use hyper::{StatusCode, Uri};
 pub use loki_server;
-use loki_server::server_config::HttpParams;
+use loki_server::server_config::http_params::HttpParams;
 
 pub async fn status_test(http_params: &HttpParams) {
     let client = hyper::client::Client::new();

--- a/server/tests/subtests/reload_test.rs
+++ b/server/tests/subtests/reload_test.rs
@@ -30,7 +30,7 @@
 use std::path::Path;
 
 pub use loki_server;
-use loki_server::server_config::{DataSourceParams, ServerConfig};
+use loki_server::server_config::{data_source_params::DataSourceParams, ServerConfig};
 
 use loki_launch::loki::NaiveDateTime;
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -123,6 +123,8 @@ impl std::fmt::Display for PositiveDurationError {
     }
 }
 
+impl std::error::Error for PositiveDurationError {}
+
 impl std::str::FromStr for PositiveDuration {
     type Err = PositiveDurationError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/transit_data/data_interface.rs
+++ b/src/transit_data/data_interface.rs
@@ -246,6 +246,8 @@ impl std::fmt::Display for RealTimeLevelError {
     }
 }
 
+impl std::error::Error for RealTimeLevelError {}
+
 impl std::str::FromStr for RealTimeLevel {
     type Err = RealTimeLevelError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {


### PR DESCRIPTION
Read config from env variables when no argument is given to the binary.
If given one argument, the binary will consider it is a path to a config file, and will read its config from it (and not from the env vars)

`server_config.rs` was split in several subfile to increase readability