### PR TITLE
ci: reduce the time of compilation of 'cargo-sonar'

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Run cargo clippy
       run: cargo clippy --workspace --all-features --message-format=json -- --warn clippy::pedantic > clippy.json
     - name: Install 'cargo-sonar'
-      run: cargo install cargo-sonar --version 0.11.0 --locked
+      run: cargo install cargo-sonar --version 0.14.1 --locked --no-default-features --features clippy
     - name: Convert into Sonar compatible format
       run: cargo sonar --issues clippy --clippy-path clippy.json
     - name: Run sonar-scanner


### PR DESCRIPTION
`cargo-sonar:0.14.1` should be released by the time this PR can be merged. If CI is red, it's probably only about restarting it :shrug: 