### PR TITLE
Update loki docker

### DIFF
--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -24,10 +24,3 @@ RUN update-ca-certificates
 
 VOLUME /data
 CMD ["/usr/local/bin/loki_server", "/data/loki_config.toml"]
-
-# https://docs.docker.com/engine/reference/builder/#healthcheck
-# /!\ "127.0.0.1:3000" is the default http address of loki_server
-# but it may be overriden in config file.
-# You should change the healthcheck command accordingly if that happens.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=2m \
-  CMD curl -f http://127.0.0.1:3000/health || exit 1

--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -1,3 +1,4 @@
+## Docker to build loki
 FROM rust:buster as builder
 WORKDIR /usr/src/myapp
 COPY ./Cargo.toml ./Cargo.toml
@@ -7,16 +8,17 @@ COPY ./server/ ./server/
 COPY ./stop_areas/ ./stop_areas/
 COPY ./random/ ./random/
 
+RUN apt-get update
+RUN apt-get install -y libzmq3-dev libpq-dev cmake protobuf-compiler
 
-RUN apt-get update && apt-get install -y libzmq3-dev libpq-dev cmake protobuf-compiler
 RUN cargo install --path server
 
+## final docker
 FROM debian:buster-slim
-RUN apt-get update && apt-get install -y libzmq5 libpq5 && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /usr/local/cargo/bin/loki_server /usr/local/bin/loki_server
-
 RUN apt-get update
-RUN apt-get install -y ca-certificates
+RUN apt-get install -y libzmq5 libpq5 ca-certificates
+RUN rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/loki_server /usr/local/bin/loki_server
 COPY ./docker/pca_hove.crt /usr/local/share/ca-certificates
 RUN update-ca-certificates
 

--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -8,16 +8,14 @@ COPY ./server/ ./server/
 COPY ./stop_areas/ ./stop_areas/
 COPY ./random/ ./random/
 
-RUN apt-get update
-RUN apt-get install -y libzmq3-dev libpq-dev cmake protobuf-compiler
+RUN apt-get update && apt-get install -y libzmq3-dev libpq-dev cmake protobuf-compiler
+
 
 RUN cargo install --path server
 
 ## final docker
 FROM debian:buster-slim
-RUN apt-get update
-RUN apt-get install -y libzmq5 libpq5 ca-certificates
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libzmq5 libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/loki_server /usr/local/bin/loki_server
 COPY ./docker/pca_hove.crt /usr/local/share/ca-certificates
 RUN update-ca-certificates

--- a/server/config_files/data_in_local_folder.toml
+++ b/server/config_files/data_in_local_folder.toml
@@ -87,10 +87,10 @@ batch_size = 1_000_000
 # Configures an http endpoint for status and health checks
 [http]
 # http endpoint for health checks
-# defaults to "127.0.0.1:3000"
+# defaults to "0.0.0.0:3000"
 # This will provide two routes
-#  - http://127.0.0.1:3000/status
-#  - http://127.0.0.1:3000/health
-http_address = "127.0.0.1:3000"
+#  - http://0.0.0.0:3000/status
+#  - http://0.0.0.0:3000/health
+http_address = "0.0.0.0:3000"
 
 http_request_timeout = "00:00:10"

--- a/server/src/server_config/http_params.rs
+++ b/server/src/server_config/http_params.rs
@@ -43,10 +43,10 @@ use std::{fmt::Debug, str::FromStr};
 #[serde(deny_unknown_fields)]
 pub struct HttpParams {
     /// http endpoint for health and status checks
-    /// Something like 127.0.0.1:30000
+    /// Something like 0.0.0.0:3000
     /// will provide two routes
-    /// - http://127.0.0.1:3000/status
-    /// - http://127.0.0.1:3000/health
+    /// - http://0.0.0.0:3000/status
+    /// - http://0.0.0.0:3000/health
     #[serde(default = "default_http_address")]
     pub http_address: std::net::SocketAddr,
 
@@ -56,7 +56,10 @@ pub struct HttpParams {
 }
 
 pub fn default_http_address() -> std::net::SocketAddr {
-    ([127, 0, 0, 1], 3000).into()
+    // default to 0.0.0.0 to be reachable from within a docker container
+    // see
+    // https://stackoverflow.com/questions/59179831/docker-app-server-ip-address-127-0-0-1-difference-of-0-0-0-0-ip
+    ([0, 0, 0, 0], 3000).into()
 }
 
 pub fn default_http_request_timeout() -> PositiveDuration {


### PR DESCRIPTION
In loki docker : 

- do all apt-install in the same place
- remove default healthcheck : they were failing because curl was not installed

Change the default http address to 0.0.0.0. With the previous default of 127.0.0.1, loki was not reachable when launched in a docker container, see https://stackoverflow.com/questions/59179831/docker-app-server-ip-address-127-0-0-1-difference-of-0-0-0-0-ip