### PR TITLE
Aws credentials for S3 bucket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,7 @@ name = "loki_server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aws-creds",
  "diesel",
  "diesel-derive-enum",
  "futures",

--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -15,7 +15,7 @@ RUN cargo install --path server
 
 ## final docker
 FROM debian:buster-slim
-RUN apt-get update && apt-get install -y libzmq5 libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libzmq5 libpq5 ca-certificates curl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/loki_server /usr/local/bin/loki_server
 COPY ./docker/pca_hove.crt /usr/local/share/ca-certificates
 RUN update-ca-certificates

--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -2,6 +2,7 @@
 FROM rust:buster as builder
 WORKDIR /usr/src/myapp
 COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
 COPY ./src/ ./src/
 COPY ./launch/ ./launch/
 COPY ./server/ ./server/

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,10 @@ lapin = "2.0"
 # Object Storage library (S3, Minio, ..)
 rust-s3 = "0.32"
 
+# Allow to make http requests from within an AWS ECS Task to obtain credentials
+# in order to access AWS S3 bucket
+aws-creds = { version = "0.30", features = ["http-credentials"] }
+
 loki_launch = { path = "../launch"}
 
 anyhow = "1"

--- a/server/config_files/data_in_s3.toml
+++ b/server/config_files/data_in_s3.toml
@@ -3,12 +3,17 @@ requests_socket = 'tcp://*:30001'
 
 [data_source]
 type = 's3'
+bucket_url = 's3.eu-west-1.amazonaws.com'
+bucket_region = 'eu-west-1'
 bucket_name = 'loki'
-bucket_region = 'http://s3_hostname/'
-bucket_access_key = 'loki_rw'
-bucket_secret_key = 'my_secret_key'
+path_style = false
 data_path_key = 'my_coverage/ntfs.zip'
 bucket_timeout = '00:01:00'
+[data_source.bucket_credentials]
+credentials_type = 'explicit'
+access_key = 'loki_rw'
+secret_key = 'my_secret_key'
+
 
 
 [default_request_params]

--- a/server/src/data_downloader.rs
+++ b/server/src/data_downloader.rs
@@ -68,7 +68,7 @@ impl DataDownloader {
         };
 
         let region = Region::Custom {
-            region: "".to_string(),
+            region: config.bucket_region.clone(),
             endpoint: config.bucket_url.clone(),
         };
 

--- a/server/src/server_config/data_source_params.rs
+++ b/server/src/server_config/data_source_params.rs
@@ -109,6 +109,7 @@ pub struct BucketParams {
     pub bucket_timeout: PositiveDuration,
 }
 
+#[must_use]
 pub fn default_bucket_credentials() -> BucketCredentials {
     BucketCredentials::AwsHttpCredentials
 }
@@ -117,6 +118,7 @@ pub fn default_bucket_timeout() -> PositiveDuration {
     PositiveDuration::from_hms(0, 0, 30)
 }
 
+#[must_use]
 pub fn default_path_style() -> bool {
     false
 }
@@ -151,12 +153,12 @@ impl BucketParams {
         );
 
         Ok(Self {
-            bucket_name,
             bucket_url,
             bucket_region,
+            bucket_name,
             path_style,
-            bucket_credentials,
             data_path_key,
+            bucket_credentials,
             bucket_timeout,
         })
     }
@@ -174,7 +176,7 @@ impl BucketCredentials {
         let credentials_type = read_env_var(
             "LOKI_BUCKET_CREDENTIALS_TYPE",
             "aws_http_credentials".to_string(),
-            |s| s.to_string(),
+            str::to_string,
         );
 
         match credentials_type.trim() {

--- a/server/src/server_config/data_source_params.rs
+++ b/server/src/server_config/data_source_params.rs
@@ -164,7 +164,7 @@ impl BucketParams {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(tag = "credentials_type", rename_all = "snake_case")]
 pub enum BucketCredentials {
     Explicit(ExplicitCredentials),
@@ -196,7 +196,7 @@ impl BucketCredentials {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ExplicitCredentials {
     pub access_key: String,

--- a/server/src/server_config/data_source_params.rs
+++ b/server/src/server_config/data_source_params.rs
@@ -79,8 +79,9 @@ impl DataSourceParams {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct BucketParams {
-    /// for example s3-eu-west-1.amazonaws.com
+    /// for example 's3-eu-west-1.amazonaws.com'
     pub bucket_url: String,
+    pub bucket_region: String,
     /// name of the bucket which should exists at bucket_url
     pub bucket_name: String,
 
@@ -128,6 +129,9 @@ impl BucketParams {
         let bucket_url = std::env::var("LOKI_BUCKET_URL")
             .context("Could not read mandatory env var LOKI_BUCKET_URL")?;
 
+        let bucket_region = std::env::var("LOKI_BUCKET_REGION")
+            .context("Could not read mandatory env var LOKI_BUCKET_REGION")?;
+
         let bucket_credentials = BucketCredentials::new_from_env_vars()
             .context("Could not read bucket credentials from env vars")?;
 
@@ -149,6 +153,7 @@ impl BucketParams {
         Ok(Self {
             bucket_name,
             bucket_url,
+            bucket_region,
             path_style,
             bucket_credentials,
             data_path_key,

--- a/server/src/server_config/data_source_params.rs
+++ b/server/src/server_config/data_source_params.rs
@@ -36,7 +36,6 @@
 
 use anyhow::{Context, Error};
 
-use lapin::protocol::access;
 use loki_launch::{
     config::{launch_params::LocalFileParams, parse_env_var, read_env_var},
     loki::PositiveDuration,


### PR DESCRIPTION
Add option to obtain IAM credentials from the environment variables set by aws in a fargate task, which are then used to access an S3 bucket to retrieve ntfs data.
The option is activated with the env variable `LOKI_BUCKET_CREDENTIALS_TYPE=aws_http_credentials`
It is still possible to use explicit access_key/secret_key for identification by setting `LOKI_BUCKET_CREDENTIALS_TYPE=explicit`