### PR TITLE
Build infos in status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -775,6 +778,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1093,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "git-version"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1124,19 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.103",
+]
+
+[[package]]
+name = "git2"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -1403,6 +1451,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,6 +1501,30 @@ name = "libc"
 version = "0.2.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55edcf6c0bb319052dea84732cf99db461780fd5e8d3eb46ab6ff312ab31f197"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.13.4+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "link-cplusplus"
@@ -1562,6 +1643,7 @@ dependencies = [
  "toml 0.5.9",
  "tracing",
  "uuid 0.8.2",
+ "vergen",
 ]
 
 [[package]]
@@ -1729,6 +1811,15 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2608,6 +2699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "rxml"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2976,6 +3073,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 dependencies = [
  "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.26.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c375d5fd899e32847b8566e10598d6e9f1d9b55ec6de3cdf9e7da4bdc51371bc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -3468,6 +3579,24 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vergen"
+version = "7.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustc_version",
+ "rustversion",
+ "sysinfo",
+ "thiserror",
+ "time 0.3.16",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,15 +1814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,20 +3067,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.26.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375d5fd899e32847b8566e10598d6e9f1d9b55ec6de3cdf9e7da4bdc51371bc"
-dependencies = [
- "cfg-if 1.0.0",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "winapi",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3593,7 +3570,6 @@ dependencies = [
  "git2",
  "rustc_version",
  "rustversion",
- "sysinfo",
  "thiserror",
  "time 0.3.16",
 ]

--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -3,6 +3,7 @@ FROM rust:buster as builder
 WORKDIR /usr/src/myapp
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
+COPY ./.git/ ./.git/
 COPY ./src/ ./src/
 COPY ./launch/ ./launch/
 COPY ./server/ ./server/

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -59,3 +59,7 @@ temp-env = "0.3"
 prost-build = "0.11"
 protobuf-codegen = "3"
 vergen = { version = "7", default-features = false, features = ["build", "rustc", "git", "cargo"] }
+
+[features]
+# enable the vehicle_loads feature on the loki lib
+vehicle_loads = ["loki_launch/vehicle_loads"]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -58,3 +58,4 @@ temp-env = "0.3"
 [build-dependencies]
 prost-build = "0.11"
 protobuf-codegen = "3"
+vergen = "7"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -58,4 +58,4 @@ temp-env = "0.3"
 [build-dependencies]
 prost-build = "0.11"
 protobuf-codegen = "3"
-vergen = "7"
+vergen = { version = "7", default-features = false, features = ["build", "rustc", "git", "cargo"] }

--- a/server/build.rs
+++ b/server/build.rs
@@ -33,7 +33,7 @@
 // channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{fs::File, io::Write};
 use vergen;
 
 static MOD_RS: &[u8] = b"

--- a/server/build.rs
+++ b/server/build.rs
@@ -33,8 +33,8 @@
 // channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
-
-use std::{fs::File, io::Write};
+use std::{fs::File, io::Write, path::PathBuf};
+use vergen;
 
 static MOD_RS: &[u8] = b"
 /// Generated from protobuf.
@@ -53,11 +53,16 @@ pub mod chaos;
 ";
 
 fn main() {
+    // generate version info from git repo
+    let mut vergen_config = vergen::Config::default();
+    *vergen_config.git_mut().semver_kind_mut() = vergen::SemverKind::Lightweight;
+    vergen::vergen(vergen_config).expect("Failed to build vergen config");
+
     // create rust usable structs from protobuf files
     // see https://docs.rs/prost-build/0.6.1/prost_build/
 
     use std::env;
-    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
 
     prost_build::compile_protos(
         &[

--- a/server/src/status_worker.rs
+++ b/server/src/status_worker.rs
@@ -61,7 +61,14 @@ use tokio::{runtime::Builder, sync::mpsc};
 
 pub const DATE_FORMAT: &str = "%Y%m%d";
 pub const DATETIME_FORMAT: &str = "%Y%m%dT%H%M%S.%f";
+
 pub const LOKI_VERSION: &str = env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT");
+pub const GIT_BRANCH: &str = env!("VERGEN_GIT_BRANCH");
+pub const GIT_COMMIT_SHA: &str = env!("VERGEN_GIT_SHA");
+pub const BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
+pub const RUSTC_VERSION: &str = env!("VERGEN_RUSTC_SEMVER");
+pub const CARGO_FEATURES: &str = env!("VERGEN_CARGO_FEATURES");
+pub const CARGO_PROFILE: &str = env!("VERGEN_CARGO_PROFILE");
 
 pub struct StatusWorker {
     status: Status,
@@ -88,6 +95,7 @@ pub struct Status {
     pub last_chaos_reload: Option<NaiveDateTime>,
     pub last_real_time_update: Option<NaiveDateTime>,
     pub loki_version: String,
+    pub build_info: BuildInfo,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -106,6 +114,29 @@ pub struct ConfigInfo {
     pub instance_name: String,
     pub realtime_contributors: Vec<String>,
     pub nb_workers: u16,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct BuildInfo {
+    pub git_branch: String,
+    pub git_commit_sha: String,
+    pub build_timestamp: String,
+    pub rustc_version: String,
+    pub cargo_features: String,
+    pub cargo_profile: String,
+}
+
+impl BuildInfo {
+    pub fn new() -> Self {
+        Self {
+            git_branch: GIT_BRANCH.to_string(),
+            git_commit_sha: GIT_COMMIT_SHA.to_string(),
+            build_timestamp: BUILD_TIMESTAMP.to_string(),
+            rustc_version: RUSTC_VERSION.to_string(),
+            cargo_features: CARGO_FEATURES.to_string(),
+            cargo_profile: CARGO_PROFILE.to_string(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -146,6 +177,7 @@ impl StatusWorker {
                 last_kirin_reload: None,
                 last_real_time_update: None,
                 loki_version: LOKI_VERSION.to_string(),
+                build_info: BuildInfo::new(),
             },
             zmq_channels,
             http_channel,

--- a/server/src/status_worker.rs
+++ b/server/src/status_worker.rs
@@ -61,7 +61,7 @@ use tokio::{runtime::Builder, sync::mpsc};
 
 pub const DATE_FORMAT: &str = "%Y%m%d";
 pub const DATETIME_FORMAT: &str = "%Y%m%dT%H%M%S.%f";
-pub const LOKI_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const LOKI_VERSION: &str = env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT");
 
 pub struct StatusWorker {
     status: Status,


### PR DESCRIPTION
Use [vergen](https://docs.rs/vergen/7.4.2/vergen/) to collect git+cargo infos at compile time (such as version number from git tags), and returns these build infos in the status http api : 

```
{
  "base_data_info": null,
  "config_info": {
    "instance_name": "my_coverage",
    "realtime_contributors": [],
    "nb_workers": 2
  },
  "last_load_succeeded": false,
  "is_realtime_loaded": false,
  "is_connected_to_rabbitmq": false,
  "realtime_queue_created": false,
  "reload_queue_created": false,
  "last_kirin_reload": null,
  "last_chaos_reload": null,
  "last_real_time_update": null,
  "loki_version": "v1.0.0-3-gb9f321a",
  "build_info": {
    "git_branch": "git_version",
    "git_commit_sha": "b9f321a3593bd4cf532d9c084aa80470c2bf2ee7",
    "build_timestamp": "2022-11-18T15:44:27.170893502Z",
    "rustc_version": "1.65.0",
    "cargo_features": "vehicle_loads",
    "cargo_profile": "debug"
  }
}
```