### PR TITLE
More docker fix

### DIFF
--- a/build_dockers.sh
+++ b/build_dockers.sh
@@ -43,13 +43,13 @@ fi
 run git submodule update --init --recursive
 
 # build the docker for binarisation
-run docker build -f docker/bina_dockerfile -t navitia/mc_bina --build-arg NAVITIA_TAG=${tag} .
+run docker build -f docker/bina_dockerfile -t navitia/mc_bina:latest --build-arg NAVITIA_TAG=${tag} .
 
 # build the docker for kraken
-run docker build -f docker/kraken_dockerfile -t navitia/mc_kraken --build-arg NAVITIA_TAG=${tag} .
+run docker build -f docker/kraken_dockerfile -t navitia/mc_kraken:latest --build-arg NAVITIA_TAG=${tag} .
 
 # build the docker for jormun
-run docker build -f docker/jormun_dockerfile -t navitia/mc_jormun --build-arg NAVITIA_TAG=${tag} .
+run docker build -f docker/jormun_dockerfile -t navitia/mc_jormun:latest --build-arg NAVITIA_TAG=${tag} .
 
 # build the docker for server
 run docker build -f docker/loki_dockerfile -t navitia/loki:dev .

--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -13,7 +13,7 @@ COPY ./random/ ./random/
 RUN apt-get update && apt-get install -y libzmq3-dev libpq-dev cmake protobuf-compiler
 
 
-RUN cargo install --path server
+RUN cargo install --locked --path server
 
 ## final docker
 FROM debian:buster-slim


### PR DESCRIPTION
-  do not ignore the Cargo.lock in loki image
Indeed `cargo install` [ignores](https://doc.rust-lang.org/cargo/commands/cargo-install.html) the Cargo.lock by default !
- be explicit on all image tags in the build_docker.sh script
