### PR TITLE
release test only for push to master

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -58,6 +58,7 @@ jobs:
         cargo test --workspace --features "loki_launch/vehicle_loads"
 
     - name: Test Release
+      if:  success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: |
         cargo test --release --workspace
         cargo test --release --workspace --features "loki_launch/vehicle_loads"


### PR DESCRIPTION
Release tests takes [around 40mn](https://github.com/hove-io/loki/actions/runs/3539580363/jobs/5941650869), even with the cache.
So let's run them only when we push to master