### PR TITLE
feat: log (TRACE) departures and arrivals during solving

### DIFF
--- a/launch/src/solver.rs
+++ b/launch/src/solver.rs
@@ -259,6 +259,23 @@ where
     Request::Criteria: Debug,
 {
     debug!("Start computing journeys");
+    trace!(
+        "Departures: {:#?}",
+        request
+            .departures()
+            .map(|departure| request.depart(&departure))
+            .map(|(stop, _)| request.stop_name(&stop))
+            .collect::<Vec<_>>()
+    );
+    trace!(
+        "Arrivals: {:#?}",
+        request
+            .arrivals()
+            .map(|arrival| request.arrival_stop(&arrival))
+            .map(|stop| request.stop_name(&stop))
+            .collect::<Vec<_>>()
+    );
+
     let start_compute_time = SystemTime::now();
     engine.compute(request);
     info!(


### PR DESCRIPTION
Note that this `trace` is already present [here](https://github.com/hove-io/loki/blob/master/launch/src/solver.rs#L171-L178) but it's not the stop names, only the stop ID which makes it hard to debug and understand... Not sure what to keep, what to remove.

Also, maybe `DEBUG` level would be better?