### PR TITLE
feat: support 'occupancy' criteria

### DIFF
--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -535,6 +535,7 @@ fn solve(
         match journey_request.criteria() {
             navitia_proto::Criteria::Classic => ComparatorType::Basic,
             navitia_proto::Criteria::Robustness => ComparatorType::Robustness,
+            navitia_proto::Criteria::Occupancy => ComparatorType::Loads,
         }
     } else {
         ComparatorType::Basic


### PR DESCRIPTION
Add support for the new `occupancy` criteria (depends on https://github.com/hove-io/loki/pull/350 and https://github.com/hove-io/navitia-proto/pull/190).