### PR TITLE
allow empty vehicle descriptor in kirin proto

### DIFF
--- a/server/src/handle_kirin_message.rs
+++ b/server/src/handle_kirin_message.rs
@@ -134,11 +134,13 @@ pub fn handle_kirin_protobuf(
     };
 
     let company_id = chaos_proto::kirin::exts::company_id.get(trip_descriptor);
-    let vehicle = trip_update
+
+    let physical_mode_id = trip_update
         .vehicle
         .as_ref()
-        .ok_or_else(|| format_err!("'TripUpdate' has no 'VehicleDescriptor'"))?;
-    let physical_mode_id = chaos_proto::kirin::exts::physical_mode_id.get(vehicle);
+        .map(|vehicle| chaos_proto::kirin::exts::physical_mode_id.get(vehicle))
+        .flatten();
+
     let headsign = chaos_proto::kirin::exts::headsign.get(trip_update);
 
     let trip_id = VehicleJourneyId {


### PR DESCRIPTION
since kirin does send messages with no vehicle descriptor