### PR TITLE
Add Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,11 +1625,13 @@ dependencies = [
  "hostname",
  "hyper",
  "lapin",
+ "lazy_static",
  "loki_launch",
  "num-traits",
+ "prometheus",
  "prost",
  "prost-build",
- "protobuf",
+ "protobuf 3.2.0",
  "protobuf-codegen",
  "rust-s3",
  "serde",
@@ -2222,6 +2224,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf 2.28.0",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2295,12 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55bad9126f378a853655831eb7363b7b01b81d19f8cb1218861086ca4a1a61e"
@@ -2295,7 +2318,7 @@ checksum = "0dd418ac3c91caa4032d37cb80ff0d44e2ebe637b2fb243b6234bf89cdac4901"
 dependencies = [
  "anyhow",
  "once_cell",
- "protobuf",
+ "protobuf 3.2.0",
  "protobuf-parse",
  "regex",
  "tempfile",
@@ -2311,7 +2334,7 @@ dependencies = [
  "anyhow",
  "indexmap",
  "log",
- "protobuf",
+ "protobuf 3.2.0",
  "protobuf-support",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1439,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +1576,12 @@ checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -2224,6 +2257,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfb6451c91904606a1abe93e83a8ec851f45827fa84273f256ade45dc095818"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "hex",
+ "lazy_static",
+ "rustix",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,8 +2278,10 @@ dependencies = [
  "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs",
  "protobuf 2.28.0",
  "thiserror",
 ]
@@ -2666,6 +2714,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -49,6 +49,9 @@ tracing = { version = "0.1", features = ["release_max_level_info"]}
 
 hyper = {version = "0.14", features = ["server", "stream"] }
 
+prometheus = "0.13"
+lazy_static = "1.4"
+
 
 [dev-dependencies]
 shiplift = "0.7" # docker API

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -49,7 +49,7 @@ tracing = { version = "0.1", features = ["release_max_level_info"]}
 
 hyper = {version = "0.14", features = ["server", "stream"] }
 
-prometheus = "0.13"
+prometheus = {version = "0.13", features = ["process"] }
 lazy_static = "1.4"
 
 

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -183,7 +183,7 @@ impl ComputeWorker {
                     )
                 });
                 let result = self.handle_schedule(request, ScheduleOn::BoardTimes);
-                metrics::observe(metrics::Metric::NetxtDeparturesArrivals, start_request_time);
+                metrics::observe(metrics::Metric::NextDeparturesArrivals, start_request_time);
                 result
             }
             navitia_proto::Api::NextArrivals => {
@@ -191,7 +191,7 @@ impl ComputeWorker {
                     format_err!("request.next_stop_times should not be empty for api NextArrivals.")
                 });
                 let result = self.handle_schedule(request, ScheduleOn::DebarkTimes);
-                metrics::observe(metrics::Metric::NetxtDeparturesArrivals, start_request_time);
+                metrics::observe(metrics::Metric::NextDeparturesArrivals, start_request_time);
                 result
             }
             _ => {

--- a/server/src/compute_worker.rs
+++ b/server/src/compute_worker.rs
@@ -38,6 +38,7 @@ use super::{navitia_proto, response};
 use crate::{
     load_balancer::WorkerId,
     master_worker::DataAndModels,
+    metrics,
     zmq_worker::{RequestMessage, ResponseMessage},
 };
 use anyhow::{format_err, Context, Error};
@@ -163,13 +164,17 @@ impl ComputeWorker {
                 let journey_request = proto_request.journeys.ok_or_else(|| {
                     format_err!("request.journey should not be empty for api PtPlanner.")
                 });
-                self.handle_journey_request(journey_request)
+                let result = self.handle_journey_request(journey_request);
+                metrics::observe(metrics::Metric::Journeys, start_request_time);
+                result
             }
             navitia_proto::Api::PlacesNearby => {
                 let places_nearby_request = proto_request.places_nearby.ok_or_else(|| {
                     format_err!("request.places_nearby should not be empty for api PlacesNearby.")
                 });
-                self.handle_places_nearby(places_nearby_request)
+                let result = self.handle_places_nearby(places_nearby_request);
+                metrics::observe(metrics::Metric::PlacesNearby, start_request_time);
+                result
             }
             navitia_proto::Api::NextDepartures => {
                 let request = proto_request.next_stop_times.ok_or_else(|| {
@@ -177,13 +182,17 @@ impl ComputeWorker {
                         "request.next_stop_times should not be empty for api NextDepartures."
                     )
                 });
-                self.handle_schedule(request, ScheduleOn::BoardTimes)
+                let result = self.handle_schedule(request, ScheduleOn::BoardTimes);
+                metrics::observe(metrics::Metric::NetxtDeparturesArrivals, start_request_time);
+                result
             }
             navitia_proto::Api::NextArrivals => {
                 let request = proto_request.next_stop_times.ok_or_else(|| {
                     format_err!("request.next_stop_times should not be empty for api NextArrivals.")
                 });
-                self.handle_schedule(request, ScheduleOn::DebarkTimes)
+                let result = self.handle_schedule(request, ScheduleOn::DebarkTimes);
+                metrics::observe(metrics::Metric::NetxtDeparturesArrivals, start_request_time);
+                result
             }
             _ => {
                 error!("I can't handle the requested api : {:?}", requested_api);
@@ -193,6 +202,7 @@ impl ComputeWorker {
                 ))
             }
         };
+
         let duration = timer::duration_since(start_request_time);
         info!(
             "Worker {} took {} ms on api {:?} for request with id '{}'",

--- a/server/src/http_worker.rs
+++ b/server/src/http_worker.rs
@@ -122,10 +122,7 @@ impl HttpWorker {
 
         let server = hyper::Server::bind(http_address).serve(make_service);
 
-        info!(
-            "Http worker is listening on http://{}/status , http://{}/health and http://{}/metrics ",
-            http_address, http_address, http_address
-        );
+        info!("Http worker is listening on http://{http_address}/",);
 
         if let Err(e) = server.await {
             error!("Http worker error: {}", e);

--- a/server/src/http_worker.rs
+++ b/server/src/http_worker.rs
@@ -123,8 +123,8 @@ impl HttpWorker {
         let server = hyper::Server::bind(http_address).serve(make_service);
 
         info!(
-            "Http worker is listening on http://{}/status and http://{}/health ",
-            http_address, http_address
+            "Http worker is listening on http://{}/status , http://{}/health and http://{}/metrics ",
+            http_address, http_address, http_address
         );
 
         if let Err(e) = server.await {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -63,6 +63,7 @@ pub mod status_worker;
 pub mod zmq_worker;
 
 pub mod data_worker;
+pub mod metrics;
 pub mod server_config;
 
 use loki_launch::loki::tracing::{debug, info};

--- a/server/src/master_worker.rs
+++ b/server/src/master_worker.rs
@@ -44,7 +44,7 @@ use std::sync::{Arc, RwLock};
 use tokio::{runtime::Builder, signal, sync::mpsc};
 
 use crate::{
-    data_worker::DataWorker, http_worker::HttpWorker, load_balancer::LoadBalancer,
+    data_worker::DataWorker, http_worker::HttpWorker, load_balancer::LoadBalancer, metrics,
     status_worker::StatusWorker, zmq_worker::ZmqWorker, ServerConfig,
 };
 
@@ -102,6 +102,8 @@ impl MasterWorker {
             shutdown_sender,
         )?;
         let _data_worker_handle = data_worker.run_in_a_thread()?;
+
+        metrics::initialize_metrics();
 
         // Master worker
         let result = Self { shutdown_receiver };

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -1,0 +1,198 @@
+use std::time::SystemTime;
+
+// Copyright  (C) 2022, Hove and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+// the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+// powered by Hove (www.kisio.com).
+// Help us simplify mobility and open public transport:
+// a non ending quest to the responsive locomotion way of traveling!
+//
+//
+// LICENCE: This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+use anyhow::{bail, Context};
+use tracing::{error, info};
+
+use prometheus::{self, Histogram, HistogramOpts, Registry};
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref METRICS: Option<Metrics> = create_metrics();
+}
+
+struct Metrics {
+    registry: Registry,
+    journeys_durations: Histogram,
+    places_nearby_durations: Histogram,
+    next_departures_arrivals_durations: Histogram,
+    zmq_status_durations: Histogram,
+    http_status_durations: Histogram,
+    reload_durations: Histogram,
+    realtime_ingestion_durations: Histogram,
+}
+
+pub enum Metric {
+    Journeys,
+    PlacesNearby,
+    NetxtDeparturesArrivals,
+    ZmqStatus,
+    HttpStatus,
+    Reload,
+    RealtimeIngestion,
+}
+
+pub fn initialize_metrics() {
+    lazy_static::initialize(&METRICS);
+}
+
+fn create_metrics() -> Option<Metrics> {
+    let registry = Registry::new_custom(Some("loki".to_string()), None)
+        .map_err(|err| error!("Failed to create prometheus registry {:?}", err))
+        .ok()?;
+    let journeys_durations = create_journeys_durations_histogram(&registry)?;
+    let places_nearby_durations = create_places_nearby_durations_histogram(&registry)?;
+    let next_departures_arrivals_durations =
+        create_next_departures_arrivals_durations_histogram(&registry)?;
+    let zmq_status_durations = create_zmq_status_histogram(&registry)?;
+    let http_status_durations = create_http_status_histogram(&registry)?;
+    let reload_durations = create_reload_histogram(&registry)?;
+    let realtime_ingestion_durations = create_realtime_ingestion_histogram(&registry)?;
+
+    info!("Metrics created");
+    Some(Metrics {
+        registry,
+        journeys_durations,
+        places_nearby_durations,
+        next_departures_arrivals_durations,
+        zmq_status_durations,
+        http_status_durations,
+        reload_durations,
+        realtime_ingestion_durations,
+    })
+}
+
+fn register_histogram(
+    registry: &Registry,
+    name: &str,
+    help: &str,
+    buckets: Vec<f64>,
+) -> Option<Histogram> {
+    let opts = HistogramOpts::new(name, help).buckets(buckets);
+    let histogram = Histogram::with_opts(opts)
+        .map_err(|err| error!("Failed to create {} histogram {:?}", name, err))
+        .ok()?;
+    registry
+        .register(Box::new(histogram.clone()))
+        .map_err(|err| error!("Failed to register {} histogram {:?}", name, err))
+        .ok()?;
+    Some(histogram)
+}
+
+fn create_journeys_durations_histogram(registry: &Registry) -> Option<Histogram> {
+    let name = "journeys_durations";
+    let help = "durations (in seconds) for handling journeys requests";
+    let buckets = vec![0.01, 0.05, 0.1, 0.2, 0.4, 1.0, 5.0];
+    register_histogram(registry, name, help, buckets)
+}
+
+fn create_places_nearby_durations_histogram(registry: &Registry) -> Option<Histogram> {
+    let name = "places_nearby_durations";
+    let help = "durations (in seconds) for handling places nearby requests";
+    let buckets = vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0];
+    register_histogram(registry, name, help, buckets)
+}
+
+fn create_next_departures_arrivals_durations_histogram(registry: &Registry) -> Option<Histogram> {
+    let name = "next_departures_arrivals_durations";
+    let help = "durations (in seconds) for handling next departures and next arrivals requests";
+    let buckets = vec![0.01, 0.05, 0.1, 0.2, 0.4, 1.0, 5.0];
+    register_histogram(registry, name, help, buckets)
+}
+
+fn create_zmq_status_histogram(registry: &Registry) -> Option<Histogram> {
+    let name = "zmq_status_durations";
+    let help = "durations (in seconds) for handling zmq status requests";
+    let buckets = vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0];
+    register_histogram(registry, name, help, buckets)
+}
+
+fn create_http_status_histogram(registry: &Registry) -> Option<Histogram> {
+    let name = "status_durations";
+    let help = "durations (in seconds) for handling http status requests";
+    let buckets = vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0];
+    register_histogram(registry, name, help, buckets)
+}
+
+fn create_reload_histogram(registry: &Registry) -> Option<Histogram> {
+    let name = "reload_durations";
+    let help = "durations (in seconds) for reloads";
+    let buckets = vec![1.0, 5.0, 20.0, 60.0, 120.0, 300.0];
+    register_histogram(registry, name, help, buckets)
+}
+
+fn create_realtime_ingestion_histogram(registry: &Registry) -> Option<Histogram> {
+    let name = "realtime_ingestion_durations";
+    let help = "durations (in seconds) for realtime ingestion";
+    let buckets = vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 60.0];
+    register_histogram(registry, name, help, buckets)
+}
+
+pub fn observe(metric: Metric, time: SystemTime) {
+    let metrics: &Metrics = match *METRICS {
+        Some(ref metrics) => metrics,
+        None => {
+            return;
+        }
+    };
+    let Ok(duration) = time.elapsed() else {
+        return;
+    };
+
+    let duration_f64 = duration.as_secs_f64();
+    let histogram = match metric {
+        Metric::Journeys => &metrics.journeys_durations,
+        Metric::PlacesNearby => &metrics.places_nearby_durations,
+        Metric::NetxtDeparturesArrivals => &metrics.next_departures_arrivals_durations,
+        Metric::ZmqStatus => &metrics.zmq_status_durations,
+        Metric::HttpStatus => &metrics.http_status_durations,
+        Metric::Reload => &metrics.reload_durations,
+        Metric::RealtimeIngestion => &metrics.realtime_ingestion_durations,
+    };
+    histogram.observe(duration_f64);
+}
+
+pub fn export_metrics() -> Result<String, anyhow::Error> {
+    let metrics: &Metrics = match *METRICS {
+        Some(ref metrics) => metrics,
+        None => {
+            bail!("Cannot export uninitalized metrics");
+        }
+    };
+
+    let metric_families = metrics.registry.gather();
+    let encoder = prometheus::TextEncoder::new();
+    encoder
+        .encode_to_string(&metric_families)
+        .context("Failed to encode metrics to String")
+}

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -142,7 +142,7 @@ fn create_zmq_status_histogram(registry: &Registry) -> Option<Histogram> {
 }
 
 fn create_http_status_histogram(registry: &Registry) -> Option<Histogram> {
-    let name = "status_durations";
+    let name = "http_status_durations";
     let help = "durations (in seconds) for handling http status requests";
     let buckets = vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0];
     register_histogram(registry, name, help, buckets)

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -33,7 +33,7 @@ use std::time::SystemTime;
 use anyhow::{bail, Context};
 use tracing::{error, info};
 
-use prometheus::{self, Histogram, HistogramOpts, Registry};
+use prometheus::{self, process_collector::ProcessCollector, Histogram, HistogramOpts, Registry};
 
 use lazy_static::lazy_static;
 
@@ -78,6 +78,12 @@ fn create_metrics() -> Option<Metrics> {
     let http_status_durations = create_http_status_histogram(&registry)?;
     let reload_durations = create_reload_histogram(&registry)?;
     let realtime_ingestion_durations = create_realtime_ingestion_histogram(&registry)?;
+
+    let process_metrics = ProcessCollector::for_self();
+    registry
+        .register(Box::new(process_metrics))
+        .map_err(|err| error!("Failed to register process metrics {:?}", err))
+        .ok()?;
 
     info!("Metrics created");
     Some(Metrics {

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -1,5 +1,3 @@
-use std::time::SystemTime;
-
 // Copyright  (C) 2022, Hove and/or its affiliates. All rights reserved.
 //
 // This file is part of Navitia,
@@ -29,8 +27,8 @@ use std::time::SystemTime;
 // channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
-
 use anyhow::{bail, Context};
+use std::time::SystemTime;
 use tracing::{error, info};
 
 use prometheus::{self, process_collector::ProcessCollector, Histogram, HistogramOpts, Registry};

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -53,7 +53,7 @@ struct Metrics {
 pub enum Metric {
     Journeys,
     PlacesNearby,
-    NetxtDeparturesArrivals,
+    NextDeparturesArrivals,
     ZmqStatus,
     HttpStatus,
     Reload,
@@ -177,7 +177,7 @@ pub fn observe(metric: Metric, time: SystemTime) {
     let histogram = match metric {
         Metric::Journeys => &metrics.journeys_durations,
         Metric::PlacesNearby => &metrics.places_nearby_durations,
-        Metric::NetxtDeparturesArrivals => &metrics.next_departures_arrivals_durations,
+        Metric::NextDeparturesArrivals => &metrics.next_departures_arrivals_durations,
         Metric::ZmqStatus => &metrics.zmq_status_durations,
         Metric::HttpStatus => &metrics.http_status_durations,
         Metric::Reload => &metrics.reload_durations,

--- a/server/src/status_worker.rs
+++ b/server/src/status_worker.rs
@@ -36,6 +36,7 @@
 
 use crate::{
     http_worker::HttpToStatusChannel,
+    metrics,
     zmq_worker::{RequestMessage, ResponseMessage, StatusWorkerToZmqChannels},
 };
 use serde::Serialize;
@@ -287,6 +288,7 @@ impl StatusWorker {
                 )
             })?;
 
+        metrics::observe(metrics::Metric::ZmqStatus, handle_request_start_time);
         let duration = timer::duration_since(handle_request_start_time);
         info!(
             "Status worker responded in {} ms to request on api {:?} with id '{}'",

--- a/server/tests/main_test.rs
+++ b/server/tests/main_test.rs
@@ -110,6 +110,7 @@ async fn run() {
 
     subtests::http_test::health_test(&config.http).await;
     subtests::http_test::status_test(&config.http).await;
+    subtests::http_test::metrics_test(&config.http).await;
 
     subtests::realtime_test::remove_add_modify_base_vj_test(&config).await;
     subtests::realtime_test::remove_add_modify_new_vj_test(&config).await;

--- a/server/tests/subtests/http_test.rs
+++ b/server/tests/subtests/http_test.rs
@@ -54,3 +54,14 @@ pub async fn health_test(http_params: &HttpParams) {
 
     assert_eq!(response.status(), StatusCode::OK);
 }
+
+pub async fn metrics_test(http_params: &HttpParams) {
+    let client = hyper::client::Client::new();
+    let address = http_params.http_address.to_string();
+    let uri_string = format!("http://{}/metrics", address);
+    let uri = Uri::from_str(&uri_string).unwrap();
+
+    let response = client.get(uri).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}


### PR DESCRIPTION
On the `/metrics` http endoint we now get : 

```text
# HELP loki_journeys_durations durations (in seconds) for handling journeys requests
# TYPE loki_journeys_durations histogram
loki_journeys_durations_bucket{le="0.01"} 1
loki_journeys_durations_bucket{le="0.05"} 2
loki_journeys_durations_bucket{le="0.1"} 2
loki_journeys_durations_bucket{le="0.2"} 2
loki_journeys_durations_bucket{le="0.4"} 2
loki_journeys_durations_bucket{le="1"} 2
loki_journeys_durations_bucket{le="5"} 2
loki_journeys_durations_bucket{le="+Inf"} 2
loki_journeys_durations_sum 0.019332518
loki_journeys_durations_count 2
# HELP loki_next_departures_arrivals_durations durations (in seconds) for handling next departures and next arrivals requests
# TYPE loki_next_departures_arrivals_durations histogram
loki_next_departures_arrivals_durations_bucket{le="0.01"} 0
loki_next_departures_arrivals_durations_bucket{le="0.05"} 0
loki_next_departures_arrivals_durations_bucket{le="0.1"} 0
loki_next_departures_arrivals_durations_bucket{le="0.2"} 0
loki_next_departures_arrivals_durations_bucket{le="0.4"} 0
loki_next_departures_arrivals_durations_bucket{le="1"} 0
loki_next_departures_arrivals_durations_bucket{le="5"} 0
loki_next_departures_arrivals_durations_bucket{le="+Inf"} 0
loki_next_departures_arrivals_durations_sum 0
loki_next_departures_arrivals_durations_count 0
# HELP loki_places_nearby_durations durations (in seconds) for handling places nearby requests
# TYPE loki_places_nearby_durations histogram
loki_places_nearby_durations_bucket{le="0.005"} 4
loki_places_nearby_durations_bucket{le="0.01"} 4
loki_places_nearby_durations_bucket{le="0.05"} 4
loki_places_nearby_durations_bucket{le="0.1"} 4
loki_places_nearby_durations_bucket{le="0.5"} 4
loki_places_nearby_durations_bucket{le="1"} 4
loki_places_nearby_durations_bucket{le="5"} 4
loki_places_nearby_durations_bucket{le="+Inf"} 4
loki_places_nearby_durations_sum 0.017049046
loki_places_nearby_durations_count 4
# HELP loki_process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE loki_process_cpu_seconds_total counter
loki_process_cpu_seconds_total 43
# HELP loki_process_max_fds Maximum number of open file descriptors.
# TYPE loki_process_max_fds gauge
loki_process_max_fds 1024
# HELP loki_process_open_fds Number of open file descriptors.
# TYPE loki_process_open_fds gauge
loki_process_open_fds 47
# HELP loki_process_resident_memory_bytes Resident memory size in bytes.
# TYPE loki_process_resident_memory_bytes gauge
loki_process_resident_memory_bytes 1661657088
# HELP loki_process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE loki_process_start_time_seconds gauge
loki_process_start_time_seconds 1669909583
# HELP loki_process_threads Number of OS threads in the process.
# TYPE loki_process_threads gauge
loki_process_threads 18
# HELP loki_process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE loki_process_virtual_memory_bytes gauge
loki_process_virtual_memory_bytes 2956881920
# HELP loki_realtime_ingestion_durations durations (in seconds) for realtime ingestion
# TYPE loki_realtime_ingestion_durations histogram
loki_realtime_ingestion_durations_bucket{le="0.005"} 0
loki_realtime_ingestion_durations_bucket{le="0.01"} 0
loki_realtime_ingestion_durations_bucket{le="0.05"} 0
loki_realtime_ingestion_durations_bucket{le="0.1"} 0
loki_realtime_ingestion_durations_bucket{le="0.5"} 0
loki_realtime_ingestion_durations_bucket{le="1"} 0
loki_realtime_ingestion_durations_bucket{le="5"} 0
loki_realtime_ingestion_durations_bucket{le="60"} 0
loki_realtime_ingestion_durations_bucket{le="+Inf"} 0
loki_realtime_ingestion_durations_sum 0
loki_realtime_ingestion_durations_count 0
# HELP loki_reload_durations durations (in seconds) for reloads
# TYPE loki_reload_durations histogram
loki_reload_durations_bucket{le="1"} 0
loki_reload_durations_bucket{le="5"} 0
loki_reload_durations_bucket{le="20"} 0
loki_reload_durations_bucket{le="60"} 0
loki_reload_durations_bucket{le="120"} 0
loki_reload_durations_bucket{le="300"} 0
loki_reload_durations_bucket{le="+Inf"} 0
loki_reload_durations_sum 0
loki_reload_durations_count 0
# HELP loki_status_durations durations (in seconds) for handling http status requests
# TYPE loki_status_durations histogram
loki_status_durations_bucket{le="0.005"} 2
loki_status_durations_bucket{le="0.01"} 2
loki_status_durations_bucket{le="0.05"} 2
loki_status_durations_bucket{le="0.1"} 2
loki_status_durations_bucket{le="0.5"} 2
loki_status_durations_bucket{le="1"} 2
loki_status_durations_bucket{le="5"} 2
loki_status_durations_bucket{le="+Inf"} 2
loki_status_durations_sum 0.000236482
loki_status_durations_count 2
# HELP loki_zmq_status_durations durations (in seconds) for handling zmq status requests
# TYPE loki_zmq_status_durations histogram
loki_zmq_status_durations_bucket{le="0.005"} 0
loki_zmq_status_durations_bucket{le="0.01"} 0
loki_zmq_status_durations_bucket{le="0.05"} 0
loki_zmq_status_durations_bucket{le="0.1"} 0
loki_zmq_status_durations_bucket{le="0.5"} 0
loki_zmq_status_durations_bucket{le="1"} 0
loki_zmq_status_durations_bucket{le="5"} 0
loki_zmq_status_durations_bucket{le="+Inf"} 0
loki_zmq_status_durations_sum 0
loki_zmq_status_durations_count 0
```