### PR TITLE
Export metrics to newrelic through opentelemetry collector

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -67,7 +67,8 @@ jobs:
     needs: checks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout loki repo
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
@@ -151,11 +152,14 @@ jobs:
     if: github.event_name == 'push'
     needs: docker
     steps:
+      - name: Checkout loki repo
+        uses: actions/checkout@v3
       - name: Push dev images to aws sandbox registry
         if:  github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           docker pull navitia/loki:dev
-          docker tag navitia/loki:dev $SBX_ECR_REGISTRY/navitia-loki-loki:dev
+          docker build -t navitia/loki:aws-dev -f docker/loki_opentelemetry_dockerfile --build-arg LOKI_TAG=dev .
+          docker tag navitia/loki:aws-dev $SBX_ECR_REGISTRY/navitia-loki-loki:dev
           aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin  $SBX_ECR_REGISTRY
           docker push $SBX_ECR_REGISTRY/navitia-loki-loki:dev
           docker logout $SBX_ECR_REGISTRY
@@ -165,7 +169,8 @@ jobs:
         run: |
           TAG=${GITHUB_REF_NAME}
           docker pull navitia/loki:$TAG
-          docker tag navitia/loki:$TAG $PRD_ECR_REGISTRY/navitia-loki-loki:$TAG
+          docker build -t navitia/loki:aws-$TAG -f docker/loki_opentelemetry_dockerfile --build-arg LOKI_TAG=$TAG .
+          docker tag navitia/loki:aws-$TAG $PRD_ECR_REGISTRY/navitia-loki-loki:$TAG
           aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin  $PRD_ECR_REGISTRY
           docker push $PRD_ECR_REGISTRY/navitia-loki-loki:$TAG
           docker logout $PRD_ECR_REGISTRY

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -158,8 +158,7 @@ jobs:
         if:  github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           docker pull navitia/loki:dev
-          docker build -t navitia/loki:aws-dev -f docker/loki_opentelemetry_dockerfile --build-arg LOKI_TAG=dev .
-          docker tag navitia/loki:aws-dev $SBX_ECR_REGISTRY/navitia-loki-loki:dev
+          docker build -t $SBX_ECR_REGISTRY/navitia-loki-loki:dev -f docker/loki_opentelemetry_dockerfile --build-arg LOKI_TAG=dev .
           aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin  $SBX_ECR_REGISTRY
           docker push $SBX_ECR_REGISTRY/navitia-loki-loki:dev
           docker logout $SBX_ECR_REGISTRY
@@ -169,8 +168,7 @@ jobs:
         run: |
           TAG=${GITHUB_REF_NAME}
           docker pull navitia/loki:$TAG
-          docker build -t navitia/loki:aws-$TAG -f docker/loki_opentelemetry_dockerfile --build-arg LOKI_TAG=$TAG .
-          docker tag navitia/loki:aws-$TAG $PRD_ECR_REGISTRY/navitia-loki-loki:$TAG
+          docker build -t $PRD_ECR_REGISTRY/navitia-loki-loki:$TAG -f docker/loki_opentelemetry_dockerfile --build-arg LOKI_TAG=$TAG .
           aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin  $PRD_ECR_REGISTRY
           docker push $PRD_ECR_REGISTRY/navitia-loki-loki:$TAG
           docker logout $PRD_ECR_REGISTRY

--- a/docker/loki_opentelemetry_dockerfile
+++ b/docker/loki_opentelemetry_dockerfile
@@ -1,0 +1,11 @@
+ARG LOKI_TAG
+FROM navitia/loki:${LOKI_TAG}
+## see https://opentelemetry.io/docs/collector/getting-started/#deb-installation
+RUN apt-get update && apt-get install -y  wget && rm -rf /var/lib/apt/lists/*
+RUN wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.66.0/otelcol-contrib_0.66.0_linux_amd64.deb
+RUN dpkg -i otelcol-contrib_0.66.0_linux_amd64.deb
+COPY ./docker/opentelemetry_exporter_config.yaml /etc/otelcol/config.yaml
+COPY ./docker/loki_opentelemetry_startup.sh /usr/local/loki_statup.sh
+RUN chmod +x /usr/local/loki_statup.sh
+
+CMD ["/usr/local/loki_statup.sh"]

--- a/docker/loki_opentelemetry_startup.sh
+++ b/docker/loki_opentelemetry_startup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Adapted from https://docs.docker.com/config/containers/multi-service_container/
+
 # Start opentelemetry exporter
 /usr/bin/otelcol-contrib --config=/etc/otelcol/config.yaml &
 

--- a/docker/loki_opentelemetry_startup.sh
+++ b/docker/loki_opentelemetry_startup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Start opentelemetry exporter
+/usr/bin/otelcol-contrib --config=/etc/otelcol/config.yaml &
+
+# Start loki
+/usr/local/bin/loki_server &
+
+# Wait for any process to exit
+wait -n
+
+# Exit with status of process that exited first
+exit $?

--- a/docker/opentelemetry_exporter_config.yaml
+++ b/docker/opentelemetry_exporter_config.yaml
@@ -23,7 +23,7 @@ processors:
 
 exporters:
   otlp:
-    # endpoint should include gRPC port number, e.g: /https://otlp.nr-data.net:4317
+    # endpoint should include gRPC port number, e.g: https://otlp.nr-data.net:4317
     # see https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup#review-settings
     endpoint: ${NEWRELIC_ENDPOINT}
     headers:

--- a/docker/opentelemetry_exporter_config.yaml
+++ b/docker/opentelemetry_exporter_config.yaml
@@ -11,7 +11,7 @@ receivers:
         - job_name: "otel-collector"
           scrape_interval: 20s
           static_configs:
-            - targets: ["LOKI_HTTP_ADDRESS"]
+            - targets: ["${LOKI_HTTP_ADDRESS}"]
   # collect metrics about the host we are running on
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
   hostmetrics:
@@ -32,17 +32,17 @@ receivers:
       #     system.filesystem.utilization:
       #       enabled: true
       network:
-      paging:
-        metrics:
-          system.paging.utilization:
-            enabled: true
-      processes:
-      process:
+      # paging:
+      #   metrics:
+      #     system.paging.utilization:
+      #       enabled: true
+      # processes:
+      # process:
 
 processors:
   memory_limiter:
     check_interval: 1s
-    limit_mib: 1000
+    limit_mib: 200
     spike_limit_mib: 200
   batch:
   # transform metrics to the "delta-encoding" which is supported by newrelic
@@ -55,10 +55,13 @@ processors:
     detectors: [env, ecs]
   # add extra attributes to the metrics collected
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/attributesprocessor/README.md#attributes-processor
-  # NewRelic expects the keys to be prefixed with 'tag.'
+  # NewRelic expects the keys to be prefixed with 'tags.'
   # https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-resources
   attributes:
     actions:
+      - key: tags.component
+        value: loki
+        action: insert
       - key: tags.availability_zone
         from_attribute: cloud.availability_zone
         action: insert
@@ -71,8 +74,13 @@ processors:
       - key: tags.cluster
         from_attribute: aws.ecs.cluster.arn
         action: insert
-      - key: tags.coverage
+      - key: coverage
         value: ${LOKI_INSTANCE_NAME}
+        action: insert
+      # https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts#host-receiver
+      - key: host.id
+        from_attribute: host.name
+        action: upsert
 
 
 exporters:

--- a/docker/opentelemetry_exporter_config.yaml
+++ b/docker/opentelemetry_exporter_config.yaml
@@ -1,0 +1,35 @@
+# adapted from :
+# - newrelic basic setup https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic/
+# - new relic collector for host monitoring https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts
+# - prometheus receiver for opentelemetry https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
+
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "otel-collector"
+          scrape_interval: 5s
+          static_configs:
+            - targets: ["127.0.0.1:3000"]
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 1000
+    spike_limit_mib: 200
+  batch:
+  cumulativetodelta:
+
+
+exporters:
+  otlp:
+    endpoint: ${NEWRELIC_ENDPOINT}
+    headers:
+      api-key: ${NEWRELIC_LICENSE_KEY}
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch, cumulativetodelta]
+      exporters: [otlp]

--- a/docker/opentelemetry_exporter_config.yaml
+++ b/docker/opentelemetry_exporter_config.yaml
@@ -4,13 +4,40 @@
 # - prometheus receiver for opentelemetry https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
 
 receivers:
+  # collect prometheus metrics exposed in loki
   prometheus:
     config:
       scrape_configs:
         - job_name: "otel-collector"
-          scrape_interval: 5s
+          scrape_interval: 20s
           static_configs:
             - targets: ["LOKI_HTTP_ADDRESS"]
+  # collect metrics about the host we are running on
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
+  hostmetrics:
+    collection_interval: 20s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+      load:
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      # disk:
+      # filesystem:
+      #   metrics:
+      #     system.filesystem.utilization:
+      #       enabled: true
+      network:
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: true
+      processes:
+      process:
 
 processors:
   memory_limiter:
@@ -18,7 +45,34 @@ processors:
     limit_mib: 1000
     spike_limit_mib: 200
   batch:
+  # transform metrics to the "delta-encoding" which is supported by newrelic
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor
+  # https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics#otel-histogram
   cumulativetodelta:
+  # collect informations about the host we are running on
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#amazon-ecs
+  resourcedetection/ecs:
+    detectors: [env, ecs]
+  # add extra attributes to the metrics collected
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/attributesprocessor/README.md#attributes-processor
+  # NewRelic expects the keys to be prefixed with 'tag.'
+  # https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-resources
+  attributes:
+    actions:
+      - key: tags.availability_zone
+        from_attribute: cloud.availability_zone
+        action: insert
+      - key: tags.task
+        from_attribute: aws.ecs.task.arn
+        action: insert
+      - key: tags.task_revision
+        from_attribute: aws.ecs.task.revision
+        action: insert
+      - key: tags.cluster
+        from_attribute: aws.ecs.cluster.arn
+        action: insert
+      - key: tags.coverage
+        value: ${LOKI_INSTANCE_NAME}
 
 
 exporters:
@@ -32,9 +86,9 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [prometheus]
+      receivers: [prometheus, hostmetrics]
       # NewRelic does not accept cumulative histogram (yet?) and that is what is produced by prometheus receiver
       # so we need to transform the cumulative histogram to a delta one
       # see https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics#otel-histogram
-      processors: [batch, cumulativetodelta]
+      processors: [batch, resourcedetection/ecs, attributes, cumulativetodelta]
       exporters: [otlp]

--- a/docker/opentelemetry_exporter_config.yaml
+++ b/docker/opentelemetry_exporter_config.yaml
@@ -10,7 +10,7 @@ receivers:
         - job_name: "otel-collector"
           scrape_interval: 5s
           static_configs:
-            - targets: ["127.0.0.1:3000"]
+            - targets: ["LOKI_HTTP_ADDRESS"]
 
 processors:
   memory_limiter:

--- a/docker/opentelemetry_exporter_config.yaml
+++ b/docker/opentelemetry_exporter_config.yaml
@@ -23,6 +23,8 @@ processors:
 
 exporters:
   otlp:
+    # endpoint should include gRPC port number, e.g: /https://otlp.nr-data.net:4317
+    # see https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup#review-settings
     endpoint: ${NEWRELIC_ENDPOINT}
     headers:
       api-key: ${NEWRELIC_LICENSE_KEY}

--- a/docker/opentelemetry_exporter_config.yaml
+++ b/docker/opentelemetry_exporter_config.yaml
@@ -33,5 +33,8 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
+      # NewRelic does not accept cumulative histogram (yet?) and that is what is produced by prometheus receiver
+      # so we need to transform the cumulative histogram to a delta one
+      # see https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics#otel-histogram
       processors: [batch, cumulativetodelta]
       exporters: [otlp]


### PR DESCRIPTION
Add opentelemetry collector in the docker image for aws.

The [opentelemetry collector](https://opentelemetry.io/docs/collector/) is configured to scrape metrics from loki, but also cpu/memory utilization and tags from the ecs task, and send them to [newrelic](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro). 
It seems that it can also be configured to send data to [other observability platforms](https://opentelemetry.io/vendors/).
