### PR TITLE
fix: fake occupancy data should load all the time

### DIFF
--- a/launch/src/read.rs
+++ b/launch/src/read.rs
@@ -172,7 +172,7 @@ fn read_loads_data_from_reader<R: std::io::Read>(
     }
     #[cfg(feature = "demo_occupancy")]
     {
-        LoadsData::fake_occupancy_metro1_rera(&model).unwrap_or_else(|err| {
+        LoadsData::fake_occupancy_metro1_rera(&_model).unwrap_or_else(|err| {
             warn!("Failed to create fake occupancy data {err}. I'll use empty loads.");
             LoadsData::empty()
         })

--- a/launch/src/read.rs
+++ b/launch/src/read.rs
@@ -159,7 +159,7 @@ fn read_loads_data_from_reader<R: std::io::Read>(
     {
         _reader
             .map(|csv_occupancy_reader| {
-                LoadsData::try_from_reader(csv_occupancy_reader, &_model).unwrap_or_else(|e| {
+                LoadsData::try_from_reader(csv_occupancy_reader, _model).unwrap_or_else(|e| {
                     warn!("failed to load passenger occupancy data: {e}");
                     warn!("initialized with empty passenger occupancy.");
                     LoadsData::empty()
@@ -172,7 +172,7 @@ fn read_loads_data_from_reader<R: std::io::Read>(
     }
     #[cfg(feature = "demo_occupancy")]
     {
-        LoadsData::fake_occupancy_metro1_rera(&_model).unwrap_or_else(|err| {
+        LoadsData::fake_occupancy_metro1_rera(_model).unwrap_or_else(|err| {
             warn!("Failed to create fake occupancy data {err}. I'll use empty loads.");
             LoadsData::empty()
         })

--- a/launch/tests/loads_test.rs
+++ b/launch/tests/loads_test.rs
@@ -40,7 +40,7 @@ use loki::{
     models::{base_model::BaseModel, real_time_model::RealTimeModel, ModelRefs},
     PositiveDuration,
 };
-use loki_launch::{config::ComparatorType, read::read_loads_data};
+use loki_launch::config::ComparatorType;
 use utils::model_builder::ModelBuilder;
 mod utils;
 
@@ -66,7 +66,7 @@ fn create_model() -> BaseModel {
         .build();
 
     let filepath = "tests/fixtures/loads_test/loads.csv";
-    let loads_data = read_loads_data(&Some(filepath.into()), &model);
+    let loads_data = loki::LoadsData::try_from_path(filepath, &model).unwrap();
 
     BaseModel::new(model, loads_data, PositiveDuration::zero()).unwrap()
 }

--- a/launch/tests/loads_test.rs
+++ b/launch/tests/loads_test.rs
@@ -66,7 +66,8 @@ fn create_model() -> BaseModel {
         .build();
 
     let filepath = "tests/fixtures/loads_test/loads.csv";
-    let loads_data = loki::LoadsData::try_from_path(filepath, &model).unwrap();
+    let reader = std::fs::File::open(&filepath).unwrap();
+    let loads_data = loki::LoadsData::try_from_reader(reader, &model).unwrap();
 
     BaseModel::new(model, loads_data, PositiveDuration::zero()).unwrap()
 }

--- a/src/loads_data/empty_loads.rs
+++ b/src/loads_data/empty_loads.rs
@@ -126,9 +126,9 @@ impl LoadsData {
         LoadsData {}
     }
 
-    pub fn new<R: io::Read>(
-        _reader: R,
-        _collections: &base_model::Collections,
+    pub fn try_from_reader<R: io::Read>(
+        _csv_occupancy_reader: R,
+        _model: &base_model::Model,
     ) -> Result<Self, Box<dyn Error>> {
         Ok(LoadsData::empty())
     }

--- a/src/loads_data/real_loads.rs
+++ b/src/loads_data/real_loads.rs
@@ -35,7 +35,7 @@
 // www.navitia.io
 
 use chrono::NaiveDate;
-use std::{collections::BTreeMap, error::Error, fmt::Display, io, path::Path};
+use std::{collections::BTreeMap, error::Error, fmt::Display, io};
 use tracing::{debug, info, trace};
 
 type StopSequence = u32;
@@ -330,14 +330,6 @@ impl LoadsData {
             }
         }
         Ok(loads_data)
-    }
-
-    pub fn try_from_path<P: AsRef<Path>>(
-        csv_occupancy_path: P,
-        model: &base_model::Model,
-    ) -> Result<Self, Box<dyn Error>> {
-        let reader = std::fs::File::open(csv_occupancy_path.as_ref())?;
-        Self::try_from_reader(reader, model)
     }
 
     pub fn try_from_reader<R: io::Read>(

--- a/src/loads_data/real_loads.rs
+++ b/src/loads_data/real_loads.rs
@@ -35,7 +35,7 @@
 // www.navitia.io
 
 use chrono::NaiveDate;
-use std::{collections::BTreeMap, error::Error, fmt::Display, io};
+use std::{collections::BTreeMap, error::Error, fmt::Display, io, path::Path};
 use tracing::{debug, info, trace};
 
 type StopSequence = u32;
@@ -332,8 +332,16 @@ impl LoadsData {
         Ok(loads_data)
     }
 
-    pub fn new<R: io::Read>(
-        csv_occupancys_reader: R,
+    pub fn try_from_path<P: AsRef<Path>>(
+        csv_occupancy_path: P,
+        model: &base_model::Model,
+    ) -> Result<Self, Box<dyn Error>> {
+        let reader = std::fs::File::open(csv_occupancy_path.as_ref())?;
+        Self::try_from_reader(reader, model)
+    }
+
+    pub fn try_from_reader<R: io::Read>(
+        csv_occupancy_reader: R,
         model: &base_model::Model,
     ) -> Result<Self, Box<dyn Error>> {
         info!("loading vehicle loads data");
@@ -342,7 +350,7 @@ impl LoadsData {
         };
         let mut reader = csv::ReaderBuilder::new()
             .delimiter(b',')
-            .from_reader(csv_occupancys_reader);
+            .from_reader(csv_occupancy_reader);
 
         let mut record = csv::StringRecord::new();
 


### PR DESCRIPTION
Changed a bit how things are done about loading occupancy data from a `Read` or from a `Path`. I've made constructors for `LoadsData` directly as method of the object instead of free functions. I've explored multiple different modifications until this proposition. None of them was really nice, the current one was the better.

Note : Sending `None` as the `loads_data_path` to existing functions was not working, because each called function was taking an `Option` as input and therefore was branching out as soon as the configuration property was not present.

- [x] Not yet tested with S3 configuration