### PR TITLE
use entrypoint instead of cmd in dockerfiles

### DIFF
--- a/docker/bina_dockerfile
+++ b/docker/bina_dockerfile
@@ -12,4 +12,4 @@ RUN chmod +x /bina.sh
 
 VOLUME /storage
 
-CMD ["/bina.sh"]
+ENTRYPOINT ["/bina.sh"]

--- a/docker/kraken_dockerfile
+++ b/docker/kraken_dockerfile
@@ -4,4 +4,4 @@ FROM navitia/kraken:${NAVITIA_TAG}
 
 VOLUME /data
 
-CMD ["/usr/bin/kraken", "/data/kraken.ini"]
+ENTRYPOINT ["/usr/bin/kraken", "/data/kraken.ini"]

--- a/docker/loki_dockerfile
+++ b/docker/loki_dockerfile
@@ -24,4 +24,4 @@ COPY ./docker/pca_hove.crt /usr/local/share/ca-certificates
 RUN update-ca-certificates
 
 VOLUME /data
-CMD ["/usr/local/bin/loki_server", "/data/loki_config.toml"]
+ENTRYPOINT ["/usr/local/bin/loki_server", "/data/loki_config.toml"]

--- a/docker/loki_opentelemetry_dockerfile
+++ b/docker/loki_opentelemetry_dockerfile
@@ -8,4 +8,4 @@ COPY ./docker/opentelemetry_exporter_config.yaml /etc/otelcol/config.yaml
 COPY ./docker/loki_opentelemetry_startup.sh /usr/local/loki_statup.sh
 RUN chmod +x /usr/local/loki_statup.sh
 
-CMD ["/usr/local/loki_statup.sh"]
+ENTRYPOINT ["/usr/local/loki_statup.sh"]


### PR DESCRIPTION
If an ENTRYPOINT exists, then CMD is interpreted as parameters given to ENTRYPOINT https://docs.docker.com/engine/reference/builder/#cmd
Since navitia/kraken  [now specify](https://github.com/hove-io/navitia/blob/df43455329ab3fe7f3b3b1947c419bbe2994f47a/docker/debian8/Dockerfile-kraken#L55) an ENTRYPOINT, the navitia/mc_kraken built here with CMD does not launch correctly